### PR TITLE
Add basic authentication mechanism to dashboard

### DIFF
--- a/pyaiot/common/auth.py
+++ b/pyaiot/common/auth.py
@@ -37,8 +37,11 @@ from random import choice
 from cryptography.fernet import Fernet
 
 DEFAULT_KEY_FILENAME = "{}/.pyaiot/keys".format(os.path.expanduser("~"))
+CREDENTIALS_FILENAME = ("{}/.pyaiot/credentials"
+                        .format(os.path.expanduser("~")))
 
 Keys = namedtuple('Keys', ['private', 'secret'])
+Credentials = namedtuple('Credentials', ['username', 'password'])
 
 
 def generate_secret_key():
@@ -64,7 +67,7 @@ def write_keys_to_file(filename, keys):
 
 
 def check_key_file(filename=DEFAULT_KEY_FILENAME):
-    """Verify that filename exists and is correctly formatted."""
+    """Verify that key filename exists and is correctly formatted."""
     filename = os.path.expanduser(filename)
     if not os.path.isfile(filename):
         raise ValueError("Key file provided doesn't exists: '{}'"
@@ -79,6 +82,25 @@ def check_key_file(filename=DEFAULT_KEY_FILENAME):
 
     return Keys(private=config['keys']['private'],
                 secret=config['keys']['secret'])
+
+
+def check_credentials_file(filename=CREDENTIALS_FILENAME):
+    """Verify that credentials filename exists and is correctly formatted."""
+    filename = os.path.expanduser(filename)
+    if not os.path.isfile(filename):
+        raise ValueError("Credentials file doesn't exists: '{}'"
+                         .format(filename))
+
+    config = configparser.ConfigParser()
+    config.read(filename)
+
+    if (not config.has_option('credentials', 'username') or
+            not config.has_option('credentials', 'password')):
+        raise ValueError("Invalid credentials file provided: '{}'"
+                         .format(filename))
+
+    return Credentials(username=config['credentials']['username'],
+                       password=config['credentials']['password'])
 
 
 def verify_auth_token(token, keys):

--- a/pyaiot/common/messaging.py
+++ b/pyaiot/common/messaging.py
@@ -61,6 +61,11 @@ class Message():
         return json.dumps({'request': 'discover'})
 
     @staticmethod
+    def new_client():
+        """Generate a text message indicating a new client."""
+        return json.dumps({'type': 'new', 'data': 'client'})
+
+    @staticmethod
     def check_ws_message(ws, raw):
         """Verify a received message is correctly formatted."""
         reason = None

--- a/pyaiot/dashboard/dashboard.py
+++ b/pyaiot/dashboard/dashboard.py
@@ -40,7 +40,8 @@ from tornado import web
 from tornado.options import define, options
 
 from pyaiot.common.auth import (check_credentials_file, CREDENTIALS_FILENAME,
-                                Credentials)
+                                Credentials, check_key_file,
+                                DEFAULT_KEY_FILENAME, auth_token)
 
 
 logging.basicConfig(level=logging.DEBUG,
@@ -52,6 +53,9 @@ logger = logging.getLogger("pyaiot.dashboard")
 class BaseHandler(web.RequestHandler):
 
     def get_current_user(self):
+        if options.insecure:
+            return "user"
+
         username = self.get_secure_cookie("username")
         password = self.get_secure_cookie("password")
         if username is None or password is None:
@@ -75,7 +79,10 @@ class LoginHandler(BaseHandler):
                     title=options.title)
 
     def get(self):
-        self._render()
+        if options.insecure:
+            self.redirect("/")
+        else:
+            self._render()
 
     def post(self):
         username = self.get_argument("username")
@@ -101,16 +108,18 @@ class DashboardHandler(BaseHandler):
                     camera_url=options.camera_url,
                     favicon=options.favicon,
                     logo_url=options.logo,
-                    title=options.title)
+                    title=options.title,
+                    mtoken=auth_token(self.application.keys))
 
 
 class IoTDashboardApplication(web.Application):
     """Tornado based web application providing an IoT Dashboard."""
 
-    def __init__(self, credentials):
+    def __init__(self, credentials, keys):
         self._nodes = {}
         self.username = credentials.username
         self.password = credentials.password
+        self.keys = keys
         if options.debug:
             logger.setLevel(logging.DEBUG)
 
@@ -118,6 +127,7 @@ class IoTDashboardApplication(web.Application):
             (r'/', DashboardHandler),
             (r"/login", LoginHandler)
         ]
+
         settings = dict(debug=True,
                         cookie_secret="MY_COOKIE_ID",
                         xsrf_cookies=True,
@@ -125,6 +135,7 @@ class IoTDashboardApplication(web.Application):
                         template_path=options.static_path,
                         login_url="/login"
                         )
+
         super().__init__(handlers, **settings)
         logger.info('Application started, listening on port {0}'
                     .format(options.port))
@@ -149,6 +160,10 @@ def parse_command_line():
            help="URL for a logo in the dashboard navbar")
     define("favicon", default=None,
            help="Favicon url for your dashboard site")
+    define("key-file", default=DEFAULT_KEY_FILENAME,
+           help="Secret and private keys filename.")
+    define("insecure", default=False,
+           help="Start the dashboard in insecure mode (no login required).")
     define("debug", default=False,
            help="Enable debug mode.")
     options.parse_command_line()
@@ -165,6 +180,12 @@ def run(arguments=[]):
         logger.setLevel(logging.DEBUG)
 
     try:
+        keys = check_key_file(options.key_file)
+    except ValueError as e:
+        logger.error(e)
+        return
+
+    try:
         credentials = check_credentials_file(CREDENTIALS_FILENAME)
     except:
         credentials = Credentials(username="default", password="default")
@@ -174,7 +195,7 @@ def run(arguments=[]):
         tornado.platform.asyncio.AsyncIOMainLoop().install()
 
         # Start tornado application
-        app = IoTDashboardApplication(credentials)
+        app = IoTDashboardApplication(credentials, keys)
         app.listen(options.port)
         ioloop.run_forever()
     except KeyboardInterrupt:

--- a/pyaiot/dashboard/static/css/dashboard.css
+++ b/pyaiot/dashboard/static/css/dashboard.css
@@ -195,3 +195,15 @@ svg.pad path:hover, svg.pad rect:hover {
     margin-left: 0px;
     margin-right: 5px;
 }
+.login {
+  -moz-box-shadow:    3px 3px 5px 6px #111;
+  -webkit-box-shadow: 3px 3px 5px 6px #111;
+  box-shadow:         3px 3px 5px 6px #111;
+  margin: 50px auto;
+  padding: 5px;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  max-width: 250px;
+  background-color: #fff;
+}

--- a/pyaiot/dashboard/static/dashboard.html
+++ b/pyaiot/dashboard/static/dashboard.html
@@ -69,6 +69,8 @@ if (theme == 'dark') {
     document.body.classList.add('dark')
 }
 
+var token = "{{ mtoken }}"
+
 var joystick = initJoystick()
 </script>
 
@@ -385,7 +387,7 @@ var ws = new WebSocket('ws://{{ wsserver }}/ws')
 
 ws.onopen = function() {
     console.log("WebSocket is ready")
-    sendData("new", "client")
+    ws.send(token)
 }
 ws.onmessage = function(event) {
     let msg = JSON.parse(event.data)

--- a/pyaiot/dashboard/static/login.html
+++ b/pyaiot/dashboard/static/login.html
@@ -43,26 +43,24 @@
     <link rel="stylesheet" type="text/css" href="{{ static_url('css/dashboard.css') }}">
 </head>
 
-<body>
-    <div class="container">
-        <div class="row">
-            <div class="col-md-4">
-            {% if error %}
-            <span style="color: red">Error: {{ error }}</span><p>
-            {% end %}
+<body style="background-color: #333;">
+    <div class="container-fluid">
+        <div class="login">
             <form action="/login" method="post">
                 <div class="form-group">
                     <label class="sr-only" for="username">Username</label>
-                    <input type="name" class="form-control" name="username" id="username" placeholder="Enter your username">
+                    <input type="name" class="form-control" name="username" id="username" placeholder="Username">
                 </div>
                 <div class="form-group">
                     <label class="sr-only" for="password">Password</label>
-                    <input type="password" class="form-control" name="password" id="password" placeholder="Enter your password">
+                    <input type="password" class="form-control" name="password" id="password" placeholder="Password">
                 </div>
                 {% module xsrf_form_html() %}
                 <button type="submit" class="btn btn-primary">Sign in</button>
+                {% if error %}
+                <br/><span style="color: red">Error: {{ error }}</span><p>
+                {% end %}
             </form>
-            </div>
         </div>
     </div>
 </body>

--- a/pyaiot/dashboard/static/login.html
+++ b/pyaiot/dashboard/static/login.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    {% if favicon %}<link rel="icon" href="{{ favicon }}">{% end %}
+    <meta name="description" content="">
+    <meta name="author" content="">
+
+    <title>{{ title }}</title>
+
+    <!-- Material Design fonts -->
+    <link rel="stylesheet" type="text/css"
+          href="//fonts.googleapis.com/css?family=Roboto:300,400,500,700">
+    <link rel="stylesheet" type="text/css"
+          href="//fonts.googleapis.com/icon?family=Material+Icons">
+
+    <!-- Bootstrap -->
+    <link rel="stylesheet" type="text/css"
+          href="{{ static_url('node_modules/bootstrap/dist/css/bootstrap.min.css') }}">
+    <!-- FontAwesome -->
+    <link rel="stylesheet" type="text/css"
+          href="{{ static_url('node_modules/font-awesome/css/font-awesome.min.css') }}">
+
+    <!-- Bootstrap Material Design -->
+    <link rel="stylesheet" type="text/css"
+          href="{{ static_url('node_modules/bootstrap-material-design/dist/css/bootstrap-material-design.min.css') }}">
+    <link rel="stylesheet" type="text/css"
+          href="{{ static_url('node_modules/bootstrap-material-design/dist/css/ripples.min.css') }}">
+
+    <!-- Javascript modules -->
+    <script type="text/javascript"
+            src="{{ static_url('node_modules/jquery/dist/jquery.min.js') }}"></script>
+    <script type="text/javascript"
+            src="{{ static_url('node_modules/bootstrap/dist/js/bootstrap.min.js') }}"></script>
+    <script type="text/javascript"
+            src="{{ static_url('node_modules/bootstrap-material-design/dist/js/material.min.js') }}"></script>
+    <script type="text/javascript"
+            src="{{ static_url('node_modules/bootstrap-material-design/dist/js/ripples.min.js') }}"></script>
+
+    <!-- IoT-Kit dashboard css -->
+    <link rel="stylesheet" type="text/css" href="{{ static_url('css/dashboard.css') }}">
+</head>
+
+<body>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-4">
+            {% if error %}
+            <span style="color: red">Error: {{ error }}</span><p>
+            {% end %}
+            <form action="/login" method="post">
+                <div class="form-group">
+                    <label class="sr-only" for="username">Username</label>
+                    <input type="name" class="form-control" name="username" id="username" placeholder="Enter your username">
+                </div>
+                <div class="form-group">
+                    <label class="sr-only" for="password">Password</label>
+                    <input type="password" class="form-control" name="password" id="password" placeholder="Enter your password">
+                </div>
+                {% module xsrf_form_html() %}
+                <button type="submit" class="btn btn-primary">Sign in</button>
+            </form>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This provides a very basic authentication mechanism to the dashboard web page:
* a simple user/password form bound to a credentials file on the dashboard application server
* a token based websocket connection from the web page to the broker. The token verification uses the time information available in the token to reject old tokens.
* added an insecure option to the dashboard if no authentication is required. In this case the token verification still remains.

There's probably room for improvement on the UI side but that works.