### PR TITLE
[WIP] Initial support for CoAP Secure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ install-dev:
 	wget -q -O - https://bootstrap.pypa.io/get-pip.py | sudo python3
 	sudo pip3 install setuptools
 	sudo apt-get install libyaml-dev libffi-dev libssl-dev npm -y
-	sudo pip3 install .
+	sudo pip3 install --upgrade . -r requirements.txt
 	make setup-dashboard-npm
 
 setup-core-services: setup-broker-service \

--- a/pyaiot/gateway/coap/application.py
+++ b/pyaiot/gateway/coap/application.py
@@ -60,8 +60,11 @@ class CoapGatewayApplication(web.Application):
         self._coap_controller = CoapController(
             on_message_cb=self.send_to_broker,
             port=options.coap_port,
-            max_time=options.max_time)
+            max_time=options.max_time,
+            dtls_enabled=options.use_coaps)
         PeriodicCallback(self._coap_controller.check_dead_nodes, 1000).start()
+
+        # NOTE: Starts a second CoAP (Secure) controller?
 
         # Create connection to broker
         self.create_broker_connection(

--- a/pyaiot/gateway/coap/coap.py
+++ b/pyaiot/gateway/coap/coap.py
@@ -45,6 +45,7 @@ logger = logging.getLogger("pyaiot.gw.coap")
 
 
 COAP_PORT = 5683
+COAPS_PORT = 5684
 MAX_TIME = 120
 PROTOCOL = "CoAP"
 
@@ -150,12 +151,13 @@ class CoapServerResource(resource.Resource):
 class CoapController():
     """CoAP controller with CoAP server inside."""
 
-    def __init__(self, on_message_cb, port=COAP_PORT, max_time=MAX_TIME):
+    def __init__(self, on_message_cb, port=COAP_PORT, max_time=MAX_TIME, dtls_enabled=False):
         # on_message_cb = send_to_broker method in gateway application
         self._on_message_cb = on_message_cb
         self.port = port
         self.max_time = max_time
         self.nodes = {}
+        self._is_secure = dtls_enabled
         self.setup()
 
     def setup(self):
@@ -166,7 +168,8 @@ class CoapController():
         root_coap.add_resource(('alive', ),
                                CoapAliveResource(self))
         asyncio.async(
-            Context.create_server_context(root_coap, bind=('::', self.port)))
+            Context.create_server_context(root_coap, bind=('::', self.port),
+                                          secure=self._is_secure ))
 
     @gen.coroutine
     def fetch_nodes_cache(self, source):

--- a/pyaiot/gateway/coap/coap.py
+++ b/pyaiot/gateway/coap/coap.py
@@ -68,7 +68,8 @@ def _coap_resource(url, method=GET, payload=b''):
         code = response.code
         payload = response.payload.decode('utf-8')
     finally:
-        yield from protocol.shutdown()
+        if protocol is not None:
+            yield from protocol.shutdown()
 
     logger.debug('Code: {0} - Payload: {1}'.format(code, payload))
 

--- a/pyaiot/gateway/coap/gateway.py
+++ b/pyaiot/gateway/coap/gateway.py
@@ -53,7 +53,11 @@ def parse_command_line():
     if not hasattr(options, "broker_port"):
         define("broker_port", default=8000, help="Broker port")
     if not hasattr(options, "coap-port"):
-        define("coap-port", default=COAP_PORT, help="Gateway CoAP server port")
+        define("coap-port", default=COAP_PORT,
+               help="Gateway CoAP server port")
+    if not hasattr(options, "coaps-port"):
+        define("coaps-port", default=COAPS_PORT,
+               help="Gateway CoAP server secure port")
     if not hasattr(options, "max_time"):
         define("max_time", default=MAX_TIME,
                help="Maximum retention time (in s) for CoAP dead nodes")
@@ -73,10 +77,6 @@ def run(arguments=[]):
         sys.argv[1:] = arguments
 
     parse_command_line()
-
-    #  Use CoAPs default port except if a custom CoAP port is set.
-    if options.use_coaps and options.coap_port is COAP_PORT:
-        options.coap_port = COAPS_PORT
 
     if options.debug:
         logger.setLevel(logging.DEBUG)

--- a/pyaiot/gateway/coap/gateway.py
+++ b/pyaiot/gateway/coap/gateway.py
@@ -37,7 +37,7 @@ from tornado.options import define, options
 from pyaiot.common.auth import check_key_file, DEFAULT_KEY_FILENAME
 from pyaiot.common.helpers import start_application
 
-from .coap import MAX_TIME, COAP_PORT
+from .coap import MAX_TIME, COAP_PORT, COAPS_PORT
 from .application import CoapGatewayApplication
 
 logging.basicConfig(level=logging.DEBUG,
@@ -62,6 +62,8 @@ def parse_command_line():
                help="Secret and private keys filename.")
     if not hasattr(options, "debug"):
         define("debug", default=False, help="Enable debug mode.")
+    if not hasattr(options, "use-coaps"):
+        define("use-coaps", default=False, help="Enable CoAP Secure.")
     options.parse_command_line()
 
 
@@ -71,6 +73,10 @@ def run(arguments=[]):
         sys.argv[1:] = arguments
 
     parse_command_line()
+
+    #  Use CoAPs default port except if a custom CoAP port is set.
+    if options.use_coaps and options.coap_port is COAP_PORT:
+        options.coap_port = COAPS_PORT
 
     if options.debug:
         logger.setLevel(logging.DEBUG)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+
+# NOTE: The official aiocoap repository does not support DTLS for
+#       the server side.
+-e git+https://github.com/rfuentess/aiocoap.git@tinydtls_server_v1#egg=aiocoap


### PR DESCRIPTION
First steps for enabling support for CoAP Secure, using tinyDTLS as the DTLS stack.

The main work for enabling DTLS relies in the aiocoap module. The changes made there are still in [WIP](https://github.com/rfuentess/aiocoap/tree/tinydtls_server_v1) status, and thus it was required  the  `-r requirements.txt` in the Makefile. 

For now my testings were only with a manual trigger of the CoAP server with: 

```
aiot-coap-gateway --key-file=~/.pyaiot/keys --use-coaps
```

Also, I think that a second CoAPController for the aiot-coap-gateway should be considered. This is with the objective of having resources listening to CoAP and CoAPS.