### PR TITLE
Fix consistent dash/underscore use in arguments

### DIFF
--- a/pyaiot/broker/broker.py
+++ b/pyaiot/broker/broker.py
@@ -50,8 +50,8 @@ def parse_command_line():
         define("port", default=8000, help="Broker websocket port")
     if not hasattr(options, "debug"):
         define("debug", default=False, help="Enable debug mode.")
-    if not hasattr(options, "key-file"):
-        define("key-file", default=DEFAULT_KEY_FILENAME,
+    if not hasattr(options, "key_file"):
+        define("key_file", default=DEFAULT_KEY_FILENAME,
                help="Secret and private keys filename.")
     options.parse_command_line()
 

--- a/pyaiot/dashboard/dashboard.py
+++ b/pyaiot/dashboard/dashboard.py
@@ -83,17 +83,17 @@ class IoTDashboardApplication(web.Application):
 
 def parse_command_line():
     """Parse command line arguments for IoT broker application."""
-    if not hasattr(options, "static-path"):
-        define("static-path",
+    if not hasattr(options, "static_path"):
+        define("static_path",
                default=os.path.join(os.path.dirname(__file__), "static"),
                help="Static files path (containing npm package.json file)")
     if not hasattr(options, "port"):
         define("port", default=8080,
                help="Web application HTTP port")
-    if not hasattr(options, "broker-port"):
+    if not hasattr(options, "broker_port"):
         define("broker_port", default=8000,
                help="Broker port")
-    if not hasattr(options, "broker-host"):
+    if not hasattr(options, "broker_host"):
         define("broker_host", default="localhost",
                help="Broker hostname")
     if not hasattr(options, "camera_url"):

--- a/pyaiot/gateway/coap/gateway.py
+++ b/pyaiot/gateway/coap/gateway.py
@@ -52,13 +52,13 @@ def parse_command_line():
         define("broker_host", default="localhost", help="Broker host")
     if not hasattr(options, "broker_port"):
         define("broker_port", default=8000, help="Broker port")
-    if not hasattr(options, "coap-port"):
-        define("coap-port", default=COAP_PORT, help="Gateway CoAP server port")
+    if not hasattr(options, "coap_port"):
+        define("coap_port", default=COAP_PORT, help="Gateway CoAP server port")
     if not hasattr(options, "max_time"):
         define("max_time", default=MAX_TIME,
                help="Maximum retention time (in s) for CoAP dead nodes")
-    if not hasattr(options, "key-file"):
-        define("key-file", default=DEFAULT_KEY_FILENAME,
+    if not hasattr(options, "key_file"):
+        define("key_file", default=DEFAULT_KEY_FILENAME,
                help="Secret and private keys filename.")
     if not hasattr(options, "debug"):
         define("debug", default=False, help="Enable debug mode.")

--- a/pyaiot/gateway/mqtt/gateway.py
+++ b/pyaiot/gateway/mqtt/gateway.py
@@ -52,15 +52,15 @@ def parse_command_line():
         define("broker_host", default="localhost", help="Pyaiot broker host")
     if not hasattr(options, "broker_port"):
         define("broker_port", default=8000, help="Pyaiot broker port")
-    if not hasattr(options, "mqtt-host"):
-        define("mqtt-host", default=MQTT_HOST, help="Gateway MQTT broker host")
-    if not hasattr(options, "mqtt-port"):
-        define("mqtt-port", default=MQTT_PORT, help="Gateway MQTT broker port")
+    if not hasattr(options, "mqtt_host"):
+        define("mqtt_host", default=MQTT_HOST, help="Gateway MQTT broker host")
+    if not hasattr(options, "mqtt_port"):
+        define("mqtt_port", default=MQTT_PORT, help="Gateway MQTT broker port")
     if not hasattr(options, "max_time"):
         define("max_time", default=MAX_TIME,
                help="Maximum retention time (in s) for CoAP dead nodes")
-    if not hasattr(options, "key-file"):
-        define("key-file", default=DEFAULT_KEY_FILENAME,
+    if not hasattr(options, "key_file"):
+        define("key_file", default=DEFAULT_KEY_FILENAME,
                help="Secret and private keys filename.")
     if not hasattr(options, "debug"):
         define("debug", default=False, help="Enable debug mode.")


### PR DESCRIPTION
This pull requests fixes some inconsistencies in dashes/underscores in the options added to tornado. 

Functionally nothing changes since tornado already converted dashes to underscores for the python accessors and converted everything to dashes for the actual argument names when calling the application.