### PR TITLE
Add option for enabling wss

### DIFF
--- a/pyaiot/dashboard/dashboard.py
+++ b/pyaiot/dashboard/dashboard.py
@@ -51,6 +51,7 @@ class DashboardHandler(web.RequestHandler):
     @tornado.web.asynchronous
     def get(self, path=None):
         self.render("dashboard.html",
+                    wsproto="wss" if options.broker_ssl else "ws",
                     wsserver="{}:{}".format(options.broker_host,
                                             options.broker_port),
                     camera_url=options.camera_url,
@@ -96,6 +97,9 @@ def parse_command_line():
     if not hasattr(options, "broker-host"):
         define("broker_host", default="localhost",
                help="Broker hostname")
+    if not hasattr(options, "broker_ssl"):
+        define("broker_ssl", type=bool, default=False,
+               help="Supply the broker websocket with ssl")
     if not hasattr(options, "camera_url"):
         define("camera_url", default=None,
                help="Default camera url")

--- a/pyaiot/dashboard/static/dashboard.html
+++ b/pyaiot/dashboard/static/dashboard.html
@@ -401,7 +401,7 @@ update_live_camera_content(vm.camUrl, vm.showCam)
 // initialize bootstrap material design
 $.material.init()
 
-var ws = new WebSocket('ws://{{ wsserver }}/ws')
+var ws = new WebSocket('{{ wsproto }}://{{ wsserver }}/ws')
 
 ws.onopen = function() {
     console.log("WebSocket is ready")


### PR DESCRIPTION
This PR adds a boolean option for the dashboard to supply the broker url with `wss://`. This is required when the application is running behind a reverse proxy that handles SSL for both the regular http requests and the websocket connection.