### PR TITLE
Config file support 

### DIFF
--- a/config-example.py
+++ b/config-example.py
@@ -1,0 +1,78 @@
+# Example configuration file for for Pyaiot
+
+# Configuration options are shared between all pyaiot components.
+
+
+# Debug
+# Enable debug logging for all components.
+#debug = False
+
+# Broker host:
+# Other component connect to this host for their broker connection. The
+# dashboard passes this hostname to the clients for their broker connection.
+#broker_host = 'localhost'
+
+# Broker port number:
+# This is the tcp port number the websocket of the broker is listening on. Other
+# component use this configuration options to determine which port number to
+# connect to.
+#broker_port = 8020
+
+# Key file
+# The key file is necessary to authenticate different components to the broker.
+# Both the broker and the other components use the path specified to find the
+# key file for authentication.
+#key_file = '~/.pyaiot/keys'
+
+# coap port
+# The coap component listens on this port for CoAP messages from nodes
+#coap_port = 5683
+
+# MQTT host
+# The hostname of the MQTT broker. The mqtt component connects to this hostname
+# for the MQTT broker connection.
+#mqtt_host = 'localhost'
+
+# MQTT port
+# The port the MQTT broker listens on. The MQTT component connects to this port
+# on the MQTT broker.
+#mqtt_port = 1886
+
+# Gateway port
+# This port is used by the websocket gateway to listen on. Websocket nodes
+# connect to this port to connect with the websocket gateway.
+#gateway_port = 8001
+
+# max time
+# Both the CoAP broker and the MQTT broker remove nodes from the broker after
+# this many seconds without any messages from a node.
+#max_time = 120
+
+# Web Port
+# The web interface listens on this port for HTTP connections.
+#web_port = 8080
+
+# Broker SSL
+# When enabled, the URI to the broker is supplied with wss to indicate to use
+# SSL to connect to the broker. Use this when you have a reverse proxy in front
+# of the dashboard to handle SSL termination.
+#broker_ssl=False
+
+# Camera URL
+# The HTTP clients get this URL for their connection to webcam images. If None
+# is configured, no webcam functionality is configured
+#camera_url = None
+
+# Title
+# The title of the web page.
+#title = 'IoT Dashboard'
+
+# Logo
+# The logo for the navbar of the dashboard. Should be an URL to the image. If
+# None is configured, no logo is shown.
+#logo = None
+
+# Favicon
+# Optionally show a favicon on the dashboard. Should be an URL to an image. If
+# None is configured, no favicon is passed to the web page.
+#favicon = None

--- a/pyaiot/broker/application.py
+++ b/pyaiot/broker/application.py
@@ -136,7 +136,7 @@ class BrokerApplication(web.Application):
 
         super().__init__(handlers, **settings)
         logger.info('Application started, listening on port {}'
-                    .format(options.port))
+                    .format(options.broker_port))
 
     def broadcast(self, message):
         """Broadcast message to all clients."""

--- a/pyaiot/gateway/coap/gateway.py
+++ b/pyaiot/gateway/coap/gateway.py
@@ -48,6 +48,8 @@ logger = logging.getLogger("pyaiot.gw.coap")
 
 def parse_command_line():
     """Parse command line arguments for CoAP gateway application."""
+    if not hasattr(options, "config"):
+        define("config", default='config.py', help="Config file")
     if not hasattr(options, "broker_host"):
         define("broker_host", default="localhost", help="Broker host")
     if not hasattr(options, "broker_port"):
@@ -63,6 +65,10 @@ def parse_command_line():
     if not hasattr(options, "debug"):
         define("debug", default=False, help="Enable debug mode.")
     options.parse_command_line()
+    if options.config:
+        options.parse_config_file(options.config)
+    # Parse the command line a second time to override config file options
+    options.parse_command_line()
 
 
 def run(arguments=[]):
@@ -70,7 +76,14 @@ def run(arguments=[]):
     if arguments != []:
         sys.argv[1:] = arguments
 
-    parse_command_line()
+    try:
+        parse_command_line()
+    except SyntaxError as e:
+        logger.critical("Invalid config file: {}".format(e))
+        return
+    except FileNotFoundError as e:
+        logger.error("Config file not found: {}".format(e))
+        return
 
     if options.debug:
         logger.setLevel(logging.DEBUG)
@@ -78,8 +91,8 @@ def run(arguments=[]):
 
     try:
         keys = check_key_file(options.key_file)
-    except ValueError as e:
-        logger.error(e)
+    except SyntaxError as e:
+        logger.error("Invalid config file: {}".format(e))
         return
 
     if not tornado.platform.asyncio.AsyncIOMainLoop().initialized():

--- a/pyaiot/gateway/coap/gateway.py
+++ b/pyaiot/gateway/coap/gateway.py
@@ -91,8 +91,8 @@ def run(arguments=[]):
 
     try:
         keys = check_key_file(options.key_file)
-    except SyntaxError as e:
-        logger.error("Invalid config file: {}".format(e))
+    except ValueError as e:
+        logger.error(e)
         return
 
     if not tornado.platform.asyncio.AsyncIOMainLoop().initialized():

--- a/pyaiot/gateway/mqtt/gateway.py
+++ b/pyaiot/gateway/mqtt/gateway.py
@@ -77,19 +77,22 @@ def run(arguments=[]):
     """Start the CoAP gateway instance."""
     if arguments != []:
         sys.argv[1:] = arguments
-
-    parse_command_line()
+    try:
+        parse_command_line()
+    except SyntaxError as e:
+        logger.error("Invalid config file: {}".format(e))
+        return
+    except FileNotFoundError as e:
+        logger.error("Config file not found: {}".format(e))
+        return
 
     if options.debug:
         logger.setLevel(logging.DEBUG)
 
     try:
         keys = check_key_file(options.key_file)
-    except SyntaxError as e:
-        logger.error("Invalid config file: {}".format(e))
-        return
-    except FileNotFoundError as e:
-        logger.error("Config file not found: {}".format(e))
+    except ValueError as e:
+        logger.error(e)
         return
 
     # Application ioloop initialization

--- a/pyaiot/gateway/mqtt/gateway.py
+++ b/pyaiot/gateway/mqtt/gateway.py
@@ -48,6 +48,8 @@ logger = logging.getLogger("pyaiot.gw.mqtt")
 
 def parse_command_line():
     """Parse command line arguments for CoAP gateway application."""
+    if not hasattr(options, "config"):
+        define("config", default='config.py', help="Config file")
     if not hasattr(options, "broker_host"):
         define("broker_host", default="localhost", help="Pyaiot broker host")
     if not hasattr(options, "broker_port"):
@@ -65,6 +67,10 @@ def parse_command_line():
     if not hasattr(options, "debug"):
         define("debug", default=False, help="Enable debug mode.")
     options.parse_command_line()
+    if options.config:
+        options.parse_config_file(options.config)
+    # Parse the command line a second time to override config file options
+    options.parse_command_line()
 
 
 def run(arguments=[]):
@@ -79,8 +85,11 @@ def run(arguments=[]):
 
     try:
         keys = check_key_file(options.key_file)
-    except ValueError as e:
-        logger.error(e)
+    except SyntaxError as e:
+        logger.error("Invalid config file: {}".format(e))
+        return
+    except FileNotFoundError as e:
+        logger.error("Config file not found: {}".format(e))
         return
 
     # Application ioloop initialization

--- a/systemd/aiot-broker.service
+++ b/systemd/aiot-broker.service
@@ -5,7 +5,7 @@ After=network.target radvd.service
 [Service]
 User=pi
 Environment='BROKER_PORT=8082'
-ExecStart=/usr/local/bin/aiot-broker --port=${BROKER_PORT}
+ExecStart=/usr/local/bin/aiot-broker --broker-port=${BROKER_PORT}
 
 [Install]
 WantedBy=multi-user.target

--- a/systemd/aiot-dashboard.service
+++ b/systemd/aiot-dashboard.service
@@ -15,7 +15,7 @@ Environment='STATIC_PATH=' \
 
 ExecStart=/usr/local/bin/aiot-dashboard \
         --static-path=${STATIC_PATH} \
-        --port=${HTTP_PORT} \
+        --web-port=${HTTP_PORT} \
         --broker-port=${BROKER_PORT} \
         --broker-host=${BROKER_HOST} \
         "--title=${APP_TITLE}" \


### PR DESCRIPTION
This PR adds configuration file support.

The command line arguments are parsed twice. Once for the configuration file option, the second time to override configuration file options by the supplied command line arguments.

Some command line options had to be changed to prevent overlap between broker and webpage options. The systemd files are changed to reflect this change.

I think the only problematic overlap between options is the max_time that with this is identical between the MQTT and the CoAP gateway and the overlap between the broker host between the dashboard and the gateways. This last one because the broker hostname supplied to the HTTP clients should probably the fqdn of the broker host, while for the gateways, localhost should often be sufficient.