### PR TITLE
Refactor applications argument parser

### DIFF
--- a/pyaiot/broker/application.py
+++ b/pyaiot/broker/application.py
@@ -30,36 +30,12 @@
 """Broker application module."""
 
 import sys
-import logging
-from tornado.options import define, options
+from tornado.options import options
 
-from pyaiot.common.auth import check_key_file, DEFAULT_KEY_FILENAME
-from pyaiot.common.helpers import start_application
+from pyaiot.common.auth import check_key_file
+from pyaiot.common.helpers import start_application, parse_command_line
 
-from .broker import Broker
-
-logging.basicConfig(level=logging.DEBUG,
-                    format='%(asctime)s - %(name)14s - '
-                           '%(levelname)5s - %(message)s')
-logger = logging.getLogger("pyaiot.broker")
-
-
-def parse_command_line():
-    """Parse command line arguments for IoT broker application."""
-    if not hasattr(options, "config"):
-        define("config", default=None, help="Config file")
-    if not hasattr(options, "port"):
-        define("broker_port", default=8000, help="Broker websocket port")
-    if not hasattr(options, "debug"):
-        define("debug", default=False, help="Enable debug mode.")
-    if not hasattr(options, "key_file"):
-        define("key_file", default=DEFAULT_KEY_FILENAME,
-               help="Secret and private keys filename.")
-    options.parse_command_line()
-    if options.config:
-        options.parse_config_file(options.config)
-    # Parse the command line a second time to override config file options
-    options.parse_command_line()
+from .broker import Broker, logger
 
 
 def run(arguments=[]):
@@ -69,15 +45,12 @@ def run(arguments=[]):
 
     try:
         parse_command_line()
-    except SyntaxError as e:
-        logger.error("Invalid config file: {}".format(e))
+    except SyntaxError as exc:
+        logger.error("Invalid config file: {}".format(exc))
         return
-    except FileNotFoundError as e:
-        logger.error("Config file not found: {}".format(e))
+    except FileNotFoundError as exc:
+        logger.error("Config file not found: {}".format(exc))
         return
-
-    if options.debug:
-        logger.setLevel(logging.DEBUG)
 
     try:
         keys = check_key_file(options.key_file)

--- a/pyaiot/common/helpers.py
+++ b/pyaiot/common/helpers.py
@@ -4,6 +4,38 @@ import logging
 import signal
 from functools import partial
 import tornado
+from tornado.options import define, options
+
+from pyaiot.common.auth import DEFAULT_KEY_FILENAME
+
+logging.basicConfig(level=logging.DEBUG,
+                    format='%(asctime)s - %(name)14s - '
+                           '%(levelname)5s - %(message)s')
+
+logger = logging.getLogger("pyaiot.helpers")
+
+
+def parse_command_line(extra_args_func=None):
+    """Parse command line arguments for any Pyaiot application."""
+    if not hasattr(options, "config"):
+        define("config", default=None, help="Config file")
+    if not hasattr(options, "broker_host"):
+        define("broker_host", default="localhost", help="Broker host")
+    if not hasattr(options, "broker_port"):
+        define("broker_port", default=8000, help="Broker websocket port")
+    if not hasattr(options, "debug"):
+        define("debug", default=False, help="Enable debug mode.")
+    if not hasattr(options, "key_file"):
+        define("key_file", default=DEFAULT_KEY_FILENAME,
+               help="Secret and private keys filename.")
+    if extra_args_func is not None:
+        extra_args_func()
+
+    options.parse_command_line()
+    if options.config:
+        options.parse_config_file(options.config)
+    # Parse the command line a second time to override config file options
+    options.parse_command_line()
 
 
 def signal_handler(server, app_close, sig, frame):
@@ -12,7 +44,7 @@ def signal_handler(server, app_close, sig, frame):
 
     def shutdown():
         """Force server and ioloop shutdown."""
-        logging.info('Shuting down server')
+        logger.info('Shuting down server')
         tornado.platform.asyncio.AsyncIOMainLoop().stop()
         if app_close is not None:
             app_close()
@@ -20,7 +52,7 @@ def signal_handler(server, app_close, sig, frame):
             server.stop()
         _ioloop.stop()
 
-    logging.warning('Caught signal: %s', sig)
+    logger.warning('Caught signal: %s', sig)
     _ioloop.add_callback_from_signal(shutdown)
 
 

--- a/pyaiot/gateway/coap/application.py
+++ b/pyaiot/gateway/coap/application.py
@@ -34,8 +34,8 @@ import logging
 import tornado.platform.asyncio
 from tornado.options import define, options
 
-from pyaiot.common.auth import check_key_file, DEFAULT_KEY_FILENAME
-from pyaiot.common.helpers import start_application
+from pyaiot.common.auth import check_key_file
+from pyaiot.common.helpers import start_application, parse_command_line
 
 from .coap import MAX_TIME, COAP_PORT
 from .gateway import CoapGateway
@@ -46,29 +46,13 @@ logging.basicConfig(level=logging.DEBUG,
 logger = logging.getLogger("pyaiot.gw.coap")
 
 
-def parse_command_line():
+def extra_args():
     """Parse command line arguments for CoAP gateway application."""
-    if not hasattr(options, "config"):
-        define("config", default=None, help="Config file")
-    if not hasattr(options, "broker_host"):
-        define("broker_host", default="localhost", help="Broker host")
-    if not hasattr(options, "broker_port"):
-        define("broker_port", default=8000, help="Broker port")
     if not hasattr(options, "coap_port"):
         define("coap_port", default=COAP_PORT, help="Gateway CoAP server port")
     if not hasattr(options, "max_time"):
         define("max_time", default=MAX_TIME,
                help="Maximum retention time (in s) for CoAP dead nodes")
-    if not hasattr(options, "key_file"):
-        define("key_file", default=DEFAULT_KEY_FILENAME,
-               help="Secret and private keys filename.")
-    if not hasattr(options, "debug"):
-        define("debug", default=False, help="Enable debug mode.")
-    options.parse_command_line()
-    if options.config:
-        options.parse_config_file(options.config)
-    # Parse the command line a second time to override config file options
-    options.parse_command_line()
 
 
 def run(arguments=[]):
@@ -77,21 +61,18 @@ def run(arguments=[]):
         sys.argv[1:] = arguments
 
     try:
-        parse_command_line()
-    except SyntaxError as e:
-        logger.critical("Invalid config file: {}".format(e))
+        parse_command_line(extra_args_func=extra_args)
+    except SyntaxError as exc:
+        logger.critical("Invalid config file: {}".format(exc))
         return
-    except FileNotFoundError as e:
-        logger.error("Config file not found: {}".format(e))
+    except FileNotFoundError as exc:
+        logger.error("Config file not found: {}".format(exc))
         return
-
-    if options.debug:
-        logger.setLevel(logging.DEBUG)
 
     try:
         keys = check_key_file(options.key_file)
-    except ValueError as e:
-        logger.error(e)
+    except ValueError as exc:
+        logger.error(exc)
         return
 
     if not tornado.platform.asyncio.AsyncIOMainLoop().initialized():

--- a/pyaiot/gateway/ws/application.py
+++ b/pyaiot/gateway/ws/application.py
@@ -33,38 +33,19 @@ import sys
 import logging
 from tornado.options import define, options
 
-from pyaiot.common.auth import check_key_file, DEFAULT_KEY_FILENAME
-from pyaiot.common.helpers import start_application
+from pyaiot.common.auth import check_key_file
+from pyaiot.common.helpers import start_application, parse_command_line
 
 from .gateway import WebsocketGateway
 
-logging.basicConfig(level=logging.DEBUG,
-                    format='%(asctime)s - %(name)14s - '
-                           '%(levelname)5s - %(message)s')
 logger = logging.getLogger("pyaiot.gw.ws")
 
 
-def parse_command_line():
+def extra_args():
     """Parse command line arguments for websocket gateway application."""
-    if not hasattr(options, "config"):
-        define("config", default=None, help="Config file")
-    if not hasattr(options, "broker_host"):
-        define("broker_host", default="localhost", help="Broker host")
-    if not hasattr(options, "broker_port"):
-        define("broker_port", default=8000, help="Broker port")
     if not hasattr(options, "gateway_port"):
         define("gateway_port", default=8001,
                help="Node gateway websocket port")
-    if not hasattr(options, "key_file"):
-        define("key_file", default=DEFAULT_KEY_FILENAME,
-               help="Secret and private keys filename.")
-    if not hasattr(options, "debug"):
-        define("debug", default=False, help="Enable debug mode.")
-    options.parse_command_line()
-    if options.config:
-        options.parse_config_file(options.config)
-    # Parse the command line a second time to override config file options
-    options.parse_command_line()
 
 
 def run(arguments=[]):
@@ -73,21 +54,18 @@ def run(arguments=[]):
         sys.argv[1:] = arguments
 
     try:
-        parse_command_line()
-    except SyntaxError as e:
-        logger.error("Invalid config file: {}".format(e))
+        parse_command_line(extra_args_func=extra_args)
+    except SyntaxError as exc:
+        logger.error("Invalid config file: {}".format(exc))
         return
-    except FileNotFoundError as e:
-        logger.error("Config file not found: {}".format(e))
+    except FileNotFoundError as exc:
+        logger.error("Config file not found: {}".format(exc))
         return
-
-    if options.debug:
-        logger.setLevel(logging.DEBUG)
 
     try:
         keys = check_key_file(options.key_file)
-    except ValueError as e:
-        logger.error(e)
+    except ValueError as exc:
+        logger.error(exc)
         return
 
     start_application(WebsocketGateway(keys, options=options),


### PR DESCRIPTION
Another step towards less code duplication: this PR tries to only declare application specific parameters along with their implementation and keep common parameters (broker-port, broker-host, debug, config, etc) in a common place.

Depends on #15