### PR TITLE
Introduce new base class for nodes controller and apply it in gateways

### DIFF
--- a/pyaiot/common/messaging.py
+++ b/pyaiot/common/messaging.py
@@ -35,6 +35,39 @@ import logging
 logger = logging.getLogger("pyaiot.messaging")
 
 
+def check_broker_data(data):
+    """"Utility function that checks the data object.
+
+    :param data: a dict with only 'uid', 'endpoint' and 'payload' keys.
+
+    :return True of the data is correct, False otherwise
+
+    >>> check_broker_data({'uid':1, 'endpoint':'/test', 'payload': 'ok'})
+    True
+    >>> check_broker_data({'endpoint':'/test', 'payload': 'ok'})
+    False
+    >>> check_broker_data({'uid':1, 'payload': 'ok'})
+    False
+    >>> check_broker_data({'uid':1, 'endpoint':'/test'})
+    False
+    >>> check_broker_data({'uid':1, 'endpoint':'/test', 'payload': 'ok',
+    ...                    'extra': 'too many'})
+    False
+    """
+
+    if 'uid' not in data:
+        logger.debug("Invalid broker data: missing uid")
+    elif 'endpoint' not in data:
+        logger.debug("Invalid broker data: missing endpoint")
+    elif 'payload' not in data:
+        logger.debug("Invalid broker data: missing payload")
+    elif len(data.keys()) > 3:
+        logger.debug("Invalid broker data: too many keys")
+    else:
+        return True
+    return False
+
+
 class Message():
     """Utility class for generating and parsing service messages."""
 
@@ -77,8 +110,8 @@ class Message():
         reason = None
         try:
             message = json.loads(raw)
-        except TypeError as e:
-            logger.warning(e)
+        except TypeError as exc:
+            logger.warning(exc)
             reason = "Invalid message '{}'.".format(raw)
             message = None
         except json.JSONDecodeError:

--- a/pyaiot/gateway/coap/coap.py
+++ b/pyaiot/gateway/coap/coap.py
@@ -40,7 +40,7 @@ from aiocoap import Context, Message, GET, PUT, CHANGED
 from aiocoap.numbers.codes import Code
 
 from pyaiot.common.messaging import Message as Msg
-from pyaiot.gateway.common import NodesControllerBase
+from pyaiot.gateway.common import NodesControllerBase, Node
 
 logger = logging.getLogger("pyaiot.gw.coap")
 
@@ -74,28 +74,6 @@ def _coap_resource(url, method=GET, payload=b''):
     logger.debug('Code: {0} - Payload: {1}'.format(code, payload))
 
     return code, payload
-
-
-class CoapNode(object):
-    """Object defining a CoAP node."""
-
-    def __init__(self, address, check_time=time.time(), endpoints=[]):
-        self.address = address
-        self.check_time = check_time
-        self.endpoints = endpoints
-
-    def __eq__(self, other):
-        return self.address == other.address
-
-    def __neq__(self, other):
-        return self.address != other.address
-
-    def __hash__(self):
-        return hash(self.address)
-
-    def __repr__(self):
-        return("Node '{}', Last check: {}, Endpoints: {}"
-               .format(self.address, self.check_time, self.endpoints))
 
 
 class CoapAliveResource(resource.Resource):
@@ -142,9 +120,9 @@ class CoapServerResource(resource.Resource):
         logger.debug("CoAP POST received from {} with payload: {}"
                      .format(remote, payload))
 
-        if CoapNode(remote) in self._controller.nodes.keys():
-            path, data = payload.split(":", 1)
-            self._controller.handle_coap_post(remote, path, data)
+        path, data = payload.split(":", 1)
+        self._controller.handle_coap_post(remote, path, data)
+
         return Message(code=CHANGED,
                        payload="Received '{}'".format(payload).encode('utf-8'))
 
@@ -157,6 +135,7 @@ class CoapNodesController(NodesControllerBase):
         self.port = port
         self.max_time = max_time
         self.setup()
+        self.node_mapping = {}  # map node address to its uuid (TODO: FIXME)
 
     def setup(self):
         """Setup CoAP resources exposed by this server."""
@@ -169,20 +148,19 @@ class CoapNodesController(NodesControllerBase):
             Context.create_server_context(root_coap, bind=('::', self.port)))
 
     @gen.coroutine
-    def discover_node(self, node, uid):
+    def discover_node(self, address, node):
         """Discover resources available on a node."""
-        coap_node_url = 'coap://[{}]'.format(node.address)
-        if len(node.endpoints) == 0:
-            logger.debug("Discovering CoAP node {}".format(node.address))
-            _, payload = yield _coap_resource('{0}/.well-known/core'
-                                              .format(coap_node_url),
-                                              method=GET)
-            node.endpoints = _coap_endpoints(payload)
+        coap_node_url = 'coap://[{}]'.format(address)
+        logger.debug("Discovering CoAP node {}".format(address))
+        _, payload = yield _coap_resource('{0}/.well-known/core'
+                                          .format(coap_node_url),
+                                          method=GET)
 
         endpoints = [endpoint
-                     for endpoint in node.endpoints
+                     for endpoint in _coap_endpoints(payload)
                      if 'well-known/core' not in endpoint]
         logger.debug("Fetching CoAP node resources: {}".format(endpoints))
+
         for endpoint in endpoints:
             elems = endpoint.split(';')
             path = elems.pop(0).replace('<', '').replace('>', '')
@@ -192,13 +170,14 @@ class CoapNodesController(NodesControllerBase):
                     '{0}{1}'.format(coap_node_url, path), method=GET)
             except:
                 logger.debug("Cannot discover ressource {} on node {}"
-                             .format(endpoint, node.address))
+                             .format(endpoint, address))
                 return
 
             # Remove '/' from path
             path = path[1:]
-            self.send_message_to_broker(Msg.update_node(uid, path, payload))
-            self.nodes[node]['data'].update({path: payload})
+            self.send_message_to_broker(
+                Msg.update_node(node.uid, path, payload))
+            self.nodes[node.uid].set_resource_value(path, payload)
 
         logger.debug("CoAP node resources '{}' sent to broker"
                      .format(endpoints))
@@ -212,69 +191,72 @@ class CoapNodesController(NodesControllerBase):
         logger.debug("Translating message ('{}') received to CoAP PUT "
                      "request".format(data))
 
-        for node, _ in self.nodes.items():
-            if self.nodes[node]['uid'] == uid:
-                address = self.nodes[node]['data']['ip']
+        for node in self.nodes.values():
+            if node.uid == uid:
+                address = node.resources['ip']
                 logger.debug("Updating CoAP node '{}' resource '{}'"
-                             .format(self.nodes[node]['data']['ip'], endpoint))
+                             .format(address, endpoint))
                 code, p = yield _coap_resource(
                     'coap://[{0}]/{1}'.format(address, endpoint),
                     method=PUT,
                     payload=payload.encode('ascii'))
                 if code == Code.CHANGED:
-                    self.nodes[node]['data'][endpoint] = payload
+                    node.set_resource_value(endpoint, payload)
                     yield self.send_message_to_broker(
                         Msg.update_node(uid, endpoint, payload))
                 break
 
     def handle_coap_post(self, address, endpoint, value):
         """Handle CoAP post message sent from coap node."""
-        node = CoapNode(address)
-        if node in self.nodes and endpoint in self.nodes[node]['data']:
-            self.nodes[node]['data'][endpoint] = value
-        self.send_message_to_broker(Msg.update_node(
-            self.nodes[node]['uid'], endpoint, value))
+        if address not in self.node_mapping:
+            logger.debug("Unknown CoAP node '{}'".format(address))
+            return
+
+        node = self.nodes[self.node_mapping[address]]
+        if endpoint in node.resources:
+            node.set_resource_value(endpoint, value)
+        self.send_message_to_broker(Msg.update_node(node.uid, endpoint, value))
 
     def handle_coap_check(self, address, reset=False):
         """Handle check message received from coap node."""
-        node = CoapNode(address)
-        node.check_time = time.time()
-        if node not in self.nodes:
+        if address not in self.node_mapping:
             # This is a totally new node: create uid, initialized cached node
             # send 'new' node notification, 'update' notification.
-            node_uid = str(uuid.uuid4())
-            self.nodes.update({node: {'uid': node_uid,
-                                      'data': {'ip': address,
-                                               'protocol': PROTOCOL}}})
-            self.send_message_to_broker(Msg.new_node(node_uid))
-            self.send_message_to_broker(Msg.update_node(node_uid,
-                                                        "ip", address))
-            self.send_message_to_broker(Msg.update_node(node_uid,
-                                                        "protocol", PROTOCOL))
-            self.discover_node(node, node_uid)
+            node = Node(str(uuid.uuid4()))
+            self.node_mapping.update({address: node.uid})
+
+            self.nodes.update({node.uid: node})
+            node.set_resource_value('ip', address)
+            node.set_resource_value('protocol', PROTOCOL)
+
+            self.send_message_to_broker(Msg.new_node(node.uid))
+            for res, value in node.resources.items():
+                self.send_message_to_broker(Msg.update_node(node.uid,
+                                                            res, value))
+            self.discover_node(address, node)
         elif reset:
             # The data of the node need to be reset without removing it. This
             # is particularly the case after a reboot of the node or a
             # firmware update of the node that triggered the reboot.
-            node_uid = self.nodes[node]['uid']
-            self.nodes[node]['data'] = {}
-            self.nodes[node]['data'].update({'ip': address,
-                                             'protocol': PROTOCOL})
-            self.send_message_to_broker(Msg.reset_node(node_uid))
-            self.discover_node(node, node_uid)
+            node = self.nodes[self.node_mapping[address]]
+            node.clear_resources()
+            node.set_resource_value('ip', address)
+            node.set_resource_value('protocol', PROTOCOL)
+            self.send_message_to_broker(Msg.reset_node(node.uid))
+            self.discover_node(address, node)
         else:
             # The node simply sent a check message to notify that it's still
             # online.
-            data = self.nodes.pop(node)
-            self.nodes.update({node: data})
+            node = self.nodes[self.node_mapping[address]]
+            node.update_last_seen()
 
     def check_dead_nodes(self):
         """Check and remove nodes that are not alive anymore."""
-        to_remove = [node for node in self.nodes.keys()
-                     if int(time.time()) > node.check_time + self.max_time]
+        to_remove = [node for node in self.nodes.values()
+                     if int(time.time()) > node.last_seen + self.max_time]
         for node in to_remove:
-            uid = self.nodes[node]['uid']
-            self.nodes.pop(node)
-            logger.info("Removing inactive node {}".format(uid))
+            self.nodes.pop(node.uid)
+            self.node_mapping.pop(node.resources['ip'])
+            logger.info("Removing inactive node {}".format(node.uid))
             logger.debug("Available nodes {}".format(self.nodes))
-            self.send_message_to_broker(Msg.out_node(uid))
+            self.send_message_to_broker(Msg.out_node(node.uid))

--- a/pyaiot/gateway/coap/gateway.py
+++ b/pyaiot/gateway/coap/gateway.py
@@ -48,10 +48,9 @@ class CoapGateway(GatewayBase):
 
     def setup_nodes_controller(self):
         """Instantiate and configure a CoAP nodes controller."""
-        nodes_controller = CoapNodesController(
-            on_message_cb=self.send_to_broker,
-            port=self.options.coap_port,
-            max_time=self.options.max_time)
+        nodes_controller = CoapNodesController(self,
+                                               port=self.options.coap_port,
+                                               max_time=self.options.max_time)
         PeriodicCallback(nodes_controller.check_dead_nodes, 1000).start()
 
         return nodes_controller

--- a/pyaiot/gateway/common/__init__.py
+++ b/pyaiot/gateway/common/__init__.py
@@ -28,3 +28,4 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from .gateway import GatewayBase
+from .nodes_controller import NodesControllerBase

--- a/pyaiot/gateway/common/__init__.py
+++ b/pyaiot/gateway/common/__init__.py
@@ -27,4 +27,4 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .common import GatewayBase
+from .gateway import GatewayBase

--- a/pyaiot/gateway/common/gateway.py
+++ b/pyaiot/gateway/common/gateway.py
@@ -43,13 +43,12 @@ logger = logging.getLogger("pyaiot.gw.common.gateway")
 class GatewayBase(web.Application, metaclass=ABCMeta):
     """Base gateway application."""
 
-    def __init__(self, keys, options):
+    def __init__(self, keys, options, handlers=[]):
         if options.debug:
             logger.setLevel(logging.DEBUG)
 
         self.broker = None
         self.keys = keys
-        handlers = []
         settings = {'debug': True}
 
         # Setup nodes controller

--- a/pyaiot/gateway/common/gateway.py
+++ b/pyaiot/gateway/common/gateway.py
@@ -27,7 +27,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-"""Common classes for gateways."""
+"""Base class for gateways."""
 
 import json
 import logging
@@ -37,7 +37,7 @@ from tornado.websocket import websocket_connect
 
 from pyaiot.common.auth import auth_token
 
-logger = logging.getLogger("pyaiot.gw.common")
+logger = logging.getLogger("pyaiot.gw.common.gateway")
 
 
 class GatewayBase(web.Application, metaclass=ABCMeta):

--- a/pyaiot/gateway/common/gateway.py
+++ b/pyaiot/gateway/common/gateway.py
@@ -36,6 +36,7 @@ from tornado import web, gen
 from tornado.websocket import websocket_connect
 
 from pyaiot.common.auth import auth_token
+from pyaiot.common.messaging import check_broker_data
 
 logger = logging.getLogger("pyaiot.gw.common.gateway")
 
@@ -112,6 +113,10 @@ class GatewayBase(web.Application, metaclass=ABCMeta):
             # Received when a new client connects => fetching the nodes
             # in controller's cache
             self._nodes_controller.fetch_nodes_cache(message['src'])
-        elif message['type'] == "update":
+        elif (message['type'] == "update" and
+              check_broker_data(message['data'])):
             # Received when a client update a node
             self._nodes_controller.send_data_to_node(message['data'])
+        else:
+            logger.debug("Invalid data received from broker '{}'."
+                         .format(message['data']))

--- a/pyaiot/gateway/common/node.py
+++ b/pyaiot/gateway/common/node.py
@@ -27,6 +27,40 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .gateway import GatewayBase
-from .nodes_controller import NodesControllerBase
-from .node import Node
+"""Class for managed node."""
+
+import logging
+import time
+
+logger = logging.getLogger("pyaiot.gw.common.node")
+
+
+class Node():
+    """Class for managed nodes."""
+
+    def __init__(self, uid):
+        self.uid = uid
+        self.last_seen = time.time()
+
+        self.resources = {}
+
+    def __eq__(self, other):
+        return self.uid == other.uid
+
+    def __gt__(self, other):
+        return self.uid > other.uid
+
+    def __repr__(self):
+        return "Node <{}>".format(self.uid)
+
+    def update_last_seen(self):
+        self.last_seen = time.time()
+
+    def set_resource_value(self, resource, value):
+        if resource not in self.resources:
+            self.resources.update({resource: value})
+        else:
+            self.resources[resource] = value
+
+    def clear_resources(self):
+        self.resources = {}

--- a/pyaiot/gateway/common/nodes_controller.py
+++ b/pyaiot/gateway/common/nodes_controller.py
@@ -76,8 +76,8 @@ class NodesControllerBase(metaclass=ABCMeta):
         """
         logger.debug("Fetching cached information of registered nodes '{}'."
                      .format(self.nodes))
-        for _, node in self.nodes.items():
-            self.send_message_to_broker(Msg.new_node(node['uid'], dst=client))
-            for resource, data in node['data'].items():
+        for node in self.nodes.values():
+            self.send_message_to_broker(Msg.new_node(node.uid, dst=client))
+            for resource, value in node.resources.items():
                 self.send_message_to_broker(
-                    Msg.update_node(node['uid'], resource, data, dst=client))
+                    Msg.update_node(node.uid, resource, value, dst=client))

--- a/pyaiot/gateway/common/nodes_controller.py
+++ b/pyaiot/gateway/common/nodes_controller.py
@@ -1,0 +1,83 @@
+# Copyright 2017 IoT-Lab Team
+# Contributor(s) : see AUTHORS file
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Base class for nodes controllers."""
+
+import logging
+
+from abc import ABCMeta, abstractmethod
+from tornado import gen
+
+from pyaiot.common.messaging import Message as Msg
+
+logger = logging.getLogger("pyaiot.gw.common.nodes")
+
+
+class NodesControllerBase(metaclass=ABCMeta):
+    """Base nodes controller class."""
+
+    def __init__(self, gateway):
+        self._gateway = gateway
+        self.nodes = {}
+
+    @abstractmethod
+    def send_data_to_node(self, data):
+        """Forward received data to the destination node.
+
+        :param data: A dict representing the data to send to the node.
+                     This dict must have the 'uid', 'endpoint' and 'payload'
+                     keys.
+                    - 'uid': the node uid (uuid)
+                    - 'endpoint': the name of the exposed resource on the node
+                    - 'payload': the payload update of the endpoint
+        """
+
+    @gen.coroutine
+    def send_message_to_broker(self, message):
+        """Send a message to the broker via the gateway.
+
+        :param message: the message to send as a string in JSON format
+
+        .. seealso Message
+        """
+        self._gateway.send_to_broker(message)
+
+    @gen.coroutine
+    def fetch_nodes_cache(self, client):
+        """Send cached nodes information to a given client.
+
+        :param client: the ID of the client
+        """
+        logger.debug("Fetching cached information of registered nodes '{}'."
+                     .format(self.nodes))
+        for _, node in self.nodes.items():
+            self.send_message_to_broker(Msg.new_node(node['uid'], dst=client))
+            for resource, data in node['data'].items():
+                self.send_message_to_broker(
+                    Msg.update_node(node['uid'], resource, data, dst=client))

--- a/pyaiot/gateway/mqtt/gateway.py
+++ b/pyaiot/gateway/mqtt/gateway.py
@@ -50,10 +50,9 @@ class MQTTGateway(GatewayBase):
 
     def setup_nodes_controller(self):
         """Instantiate and configure an MQTT nodes controller."""
-        nodes_controller = MQTTNodesController(
-            on_message_cb=self.send_to_broker,
-            port=self.options.mqtt_port,
-            max_time=self.options.max_time)
+        nodes_controller = MQTTNodesController(self,
+                                               port=self.options.mqtt_port,
+                                               max_time=self.options.max_time)
         PeriodicCallback(nodes_controller.check_dead_nodes, 1000).start()
         PeriodicCallback(nodes_controller.request_alive, 30000).start()
 


### PR DESCRIPTION
Small refactoring of the nodes controller classes: the idea it to use a common base class for all gateways (since they share some features) and to use it the existing gateways.

This also guarantees that customs gateways are compliant with the nodes controller interface (2 methods are required).

Maybe @bergzand, you want to have a look ?