### PR TITLE
docker: add buildx to build for multiple archs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,86 @@
+name: docker
+
+on:
+  push:
+    branches: master
+
+jobs:
+  build-base:
+    name: Build and push base image
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./docker/base/Dockerfile
+          platforms: linux/arm64/v8,linux/amd64
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/base:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+  build-other:
+    needs: build-base
+    strategy:
+      fail-fast: false
+      matrix:
+        images: [broker, coap-gw, dashboard]
+    name: Build and push ${{ matrix.images }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: ${{ runner.os }}-buildx-
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: ./docker/${{ matrix.images }}/
+          file: ./docker/${{ matrix.images }}/Dockerfile
+          platforms: linux/arm64/v8,linux/amd64
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/${{ matrix.images }}:latest
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,23 +1,38 @@
-CONTAINERS = base broker dashboard coap-gw
+CONTAINERS = base broker coap-gw dashboard
 BUILD_TARGETS = $(addprefix build-,$(CONTAINERS))
 PUSH_TARGETS = $(addprefix push-,$(CONTAINERS))
+BUILD_PUSH_TARGETS = $(addprefix buildx-push-,$(CONTAINERS))
 
-.PHONY: all build build-% push push-%
+VERSION ?= latest
+DOCKERHUB ?= pyaiot
+
+.PHONY: all build build-% push push-% buildx buildx%
 
 all: build
 
 build: $(BUILD_TARGETS)
 
 build-%:
-	@echo "**** Build container pyaiot/$* ****"
-	@docker build $* -t pyaiot/$*
+	@echo "**** Build container $(DOCKERHUB)/$* ****"
+	@docker build $* -t $(DOCKERHUB)/$*
 	@echo "**** Done ****"
 	@echo
 
 push: $(PUSH_TARGETS)
 
 push-%:
-	@echo "**** Push container pyaiot/$* ****"
-	docker push pyaiot/$*:latest
+	@echo "**** Push container $(DOCKERHUB)/$* ****"
+	docker push $(DOCKERHUB)/$*:$(VERSION)
+	@echo "**** Done ****"
+	@echo
+
+buildx-push: $(BUILD_PUSH_TARGETS)
+
+$(filter-out %base,$(BUILD_PUSH_TARGETS)): buildx-push-base
+buildx-push-%:
+	@echo "**** Build and push container $(DOCKERHUB)/$* ****"
+	@docker buildx build $* \
+		--platform linux/arm64/v8,linux/amd64 \
+		-t $(DOCKERHUB)/$*:$(VERSION) --push
 	@echo "**** Done ****"
 	@echo

--- a/docker/broker/run.sh
+++ b/docker/broker/run.sh
@@ -1,3 +1,7 @@
 #!/bin/bash
 
-aiot-broker --debug
+: ${BROKER_HOST:=pyaiot-broker}
+: ${BROKER_PORT:=8000}
+
+aiot-broker --broker-host=${BROKER_HOST} --broker-port=${BROKER_PORT} \
+            --debug

--- a/docker/dashboard/run.sh
+++ b/docker/dashboard/run.sh
@@ -2,9 +2,11 @@
 
 : ${BROKER_HOST:=localhost}
 : ${BROKER_PORT:=8000}
+: ${WEB_PORT:=8080}
 : ${MAP_API_KEY}:=invalid}
 
 aiot-dashboard --broker-host=${BROKER_HOST} --broker-port=${BROKER_PORT} \
+                --web-port=${WEB_PORT} \
                 --map-api-key=${MAP_API_KEY} \
                 --static-path=/opt/pyaiot/pyaiot/dashboard/static \
                 --debug


### PR DESCRIPTION
To work this PR will require that the following secrets are configured:
```
DOCKERHUB_USERNAME
DOCKERHUB_TOKEN
```

This pr adds buildx to build for multiple archs, allowing the images to be deployed on RPI3B+ and RPI4 (other platforms showed issues during builds steps, which can be added as needed). Building and pushing are not decoupled so a separate target is added for this.

A build result can be seen https://github.com/fjmolinas/pyaiot/actions/runs/521046487.