### PR TITLE
pyaiot/common/helpers.py: allow empty broker port

### DIFF
--- a/pyaiot/common/helpers.py
+++ b/pyaiot/common/helpers.py
@@ -22,7 +22,8 @@ def parse_command_line(extra_args_func=None):
     if not hasattr(options, "broker_host"):
         define("broker_host", default="localhost", help="Broker host")
     if not hasattr(options, "broker_port"):
-        define("broker_port", default=8000, help="Broker websocket port")
+        define("broker_port", default=8000, type=str,
+               help="Broker websocket port")
     if not hasattr(options, "debug"):
         define("debug", default=False, help="Enable debug mode.")
     if not hasattr(options, "key_file"):


### PR DESCRIPTION
Behind a VPN one might only want to expose port 80 for the public
dashboard and broker.

Internally a proxy would be used to redirect websocket requests
to the broker, for this the websocket port should not be specified.