### PR TITLE
pyaiot/gateway/coap/application: do not set port, asyncio coroutine will

### DIFF
--- a/pyaiot/gateway/coap/application.py
+++ b/pyaiot/gateway/coap/application.py
@@ -78,7 +78,7 @@ def run(arguments=[]):
         return
 
     start_application(CoapGateway(keys, options=options),
-                      port=options.coap_port, close_client=True)
+                      port=None, close_client=True)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR sets the port to None when starting the aiot-coap-gw, otherwise there is a port clash since the asyncio cotourine will start listening on that port as well.