### PR TITLE
pyaiot/gateway/edhoc: add optional payload encryption/decryption

### DIFF
--- a/bin/aiot-add-key
+++ b/bin/aiot-add-key
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+
+# Copyright 2017 IoT-Lab Team
+# Contributor(s) : see AUTHORS file
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import argparse
+import base64
+from pyaiot.common.edhoc_keys import (
+    add_peer_cred, DEFAULT_PEER_CRED_FILENAME)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument("key", type=str, help="the base64 encode RPK")
+parser.add_argument("kid", type=str, help="the base64 kid for the RPK")
+
+
+def main(key, kid):
+    """Main function."""
+    key = base64.b64decode(key.encode())
+    kid = base64.b64decode(kid.encode())
+    add_peer_cred(key, kid)
+
+    message = ("EDHOC added key:\n\n"
+               "   - RPK: \t\n{} kid:{}\n\n")
+
+    print(message.format(key, kid))
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    main(args.key, args.kid)

--- a/bin/aiot-generate-edhoc
+++ b/bin/aiot-generate-edhoc
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+# Copyright 2017 IoT-Lab Team
+# Contributor(s) : see AUTHORS file
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import os
+from cryptography.hazmat.primitives import serialization
+from pyaiot.common.edhoc_keys import (generate_ed25519_priv_key,
+                                      priv_key_serialize_pem,
+                                      pub_key_serialize_pem,
+                                      write_edhoc_credentials,
+                                      add_peer_cred,
+                                      rmv_peer_cred,
+                                      DEFAULT_AUTHKEY_FILENAME,
+                                      DEFAULT_AUTHCRED_FILENAME,
+                                      DEFAULT_GATEWAY_RPK_KID)
+
+
+def main():
+    """Main function."""
+    authkey = generate_ed25519_priv_key()
+    authcred = authkey.public_key()
+    write_edhoc_credentials(authkey)
+    rpk_bytes = authcred.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    rmv_peer_cred(DEFAULT_GATEWAY_RPK_KID)
+    add_peer_cred(rpk_bytes, DEFAULT_GATEWAY_RPK_KID)
+    message = ("EDHOC credentials generation done:\n\n"
+               "   - Authentication Key:  \t\n{}\n"
+               "   - Credentials: \t\n{}\n"
+               "The keys have been written in {} and {}")
+
+    print(message.format(priv_key_serialize_pem(authkey),
+                         pub_key_serialize_pem(authcred),
+                         DEFAULT_AUTHKEY_FILENAME,
+                         DEFAULT_AUTHCRED_FILENAME))
+
+
+if __name__ == "__main__":
+    main()

--- a/pyaiot/common/crypto.py
+++ b/pyaiot/common/crypto.py
@@ -1,0 +1,162 @@
+
+"""pyaiot message encryption module"""
+
+import base64
+import json
+from dataclasses import dataclass, asdict
+from typing import ByteString, Any
+
+from cryptography.hazmat.primitives.ciphers.aead import AESCCM
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+from cose import headers
+from cose.messages import Enc0Message
+from cose.messages import CoseMessage
+from cose.algorithms import AESCCM1664128
+from cose.keys.keyparam import KpKid, KpAlg
+from cose.keys import SymmetricKey
+
+
+def bxor(ba1: ByteString, ba2: ByteString) -> ByteString:
+    """ XOR two byte strings """
+    return bytes([_a ^ _b for _a, _b in zip(ba1, ba2)])
+
+
+def from_str(x: Any) -> str:
+    assert isinstance(x, str)
+    return x
+
+
+@dataclass
+class CypherMessage:
+    ct: str  # bas64 encoded
+    aad: str  # base64 encoded
+
+    def to_json_str(self) -> str:
+        json_dict = asdict(self)
+        return json.dumps(json_dict)
+
+    @staticmethod
+    def from_dict(obj: Any) -> 'CypherMessage':
+        assert isinstance(obj, dict)
+        ct = from_str(obj.get("ct"))
+        aad = from_str(obj.get("aad"))
+        return CypherMessage(ct, aad)
+
+    @staticmethod
+    def from_json_str(json_string: str):
+        json_dict = json.loads(json_string)
+        return CypherMessage.from_dict(json_dict)
+
+    @property
+    def ct_bas64_decode(self) -> ByteString:
+        return base64.b64decode(self.ct.encode('utf-8'))
+
+    @property
+    def aad_bas64_decode(self) -> ByteString:
+        return base64.b64decode(self.aad.encode('utf-8'))
+
+
+class CryptoCtx():
+    NONCE_LENGTH = 13
+    COMMON_IV_LENGTH = 13
+    AES_CCM_KEY_LENGTH = 16  # 128 bits
+    AES_CCM_TAG_LENGTH_BYTES = 8  # 64bits
+    CTX_ID_MAX_LEN = 6
+
+    def __init__(self, send_ctx_id: ByteString, recv_ctx_id: ByteString):
+        self.send_ctx_key = None
+        self.recv_ctx_key = None
+        self.common_iv = None
+        self.seq_nr = 0
+        self.send_ctx_id = send_ctx_id
+        self.recv_ctx_id = recv_ctx_id
+
+    @staticmethod
+    def __aes_ccm_key(salt: ByteString, secret: ByteString, info: ByteString,
+                      length: int = AES_CCM_KEY_LENGTH) -> ByteString:
+        hkdf = HKDF(algorithm=hashes.SHA256(), salt=salt, info=info,
+                    length=length)
+        key = hkdf.derive(secret)
+        hkdf = HKDF(algorithm=hashes.SHA256(), salt=salt, info=info,
+                    length=length)
+        hkdf.verify(secret, key)
+        return key
+
+    def encrypt(self, data: ByteString, aad: ByteString) -> ByteString:
+        """Encrypts plaintext"""
+        nonce = self.gen_nonce(self.send_ctx_id)
+        aesccm = AESCCM(self.send_ctx_key, self.AES_CCM_TAG_LENGTH_BYTES)
+        return aesccm.encrypt(nonce, data, aad)
+
+    def decrypt(self, cdata: ByteString, aad: ByteString) -> ByteString:
+        """Decrypt aes CCM cyphered data"""
+        nonce = self.gen_nonce(self.recv_ctx_id)
+        aesccm = AESCCM(self.recv_ctx_key, self.AES_CCM_TAG_LENGTH_BYTES)
+        return aesccm.decrypt(nonce, cdata, aad)
+
+    def gen_nonce(self, ctx_id: ByteString) -> ByteString:
+        """Generates a nonce for a specific context id, sequence number
+        is incremented after generating the nonce"""
+        pad_seq_nr = list(self.seq_nr.to_bytes(5, byteorder='big'))
+        pad_ctx_id = (self.NONCE_LENGTH - 5 - len(ctx_id)) * [0] + list(ctx_id)
+        partial_iv = bytes(pad_ctx_id + pad_seq_nr)
+        self.seq_nr += 1
+        return bxor(self.common_iv, partial_iv)
+
+    def generate_aes_ccm_keys(self, salt: ByteString,
+                              secret: ByteString) -> None:
+        """Generates recv_ctx_key, send_ctx_key and common_iv from"""
+        self.recv_ctx_key = CryptoCtx.__aes_ccm_key(salt, secret,
+                                                    self.recv_ctx_id)
+        self.send_ctx_key = CryptoCtx.__aes_ccm_key(salt, secret,
+                                                    self.send_ctx_id)
+        self.common_iv = CryptoCtx.__aes_ccm_key(salt, secret, b'',
+                                                 length=self.COMMON_IV_LENGTH)
+
+    def create_msg(self, plain_text: str) -> str:
+        """Encrypts plaintext data and returns a JSON string CypherMessage"""
+        # convert from string to ByteString
+        pt = plain_text.encode('utf-8')
+        aad = str(self.seq_nr).encode('utf-8')
+        # encrypt and base64 encode for serialization
+        ct = self.encrypt(pt, aad)
+        ct_b64_s = base64.b64encode(ct).decode('utf-8')
+        aad_b64_s = base64.b64encode(aad).decode('utf-8')
+        return CypherMessage(ct_b64_s, aad_b64_s).to_json_str()
+
+    def parse_msg(self, msg: str) -> str:
+        """Parses a received encrypted messaged and returns the plain
+        text data"""
+        cm = CypherMessage.from_json_str(msg)
+        aad = cm.aad_bas64_decode
+        ct = cm.ct_bas64_decode
+        pt = self.decrypt(ct, aad)
+        return pt.decode('utf-8')
+
+    def decrypt_msg(self, msg: ByteString) -> str:
+        """Returns a decoded COSE Encrypt0 message"""
+        cose_msg = CoseMessage.decode(msg)
+        cose_key = SymmetricKey(self.recv_ctx_key,
+                                optional_params={
+                                    KpKid: self.recv_ctx_id,
+                                    KpAlg: AESCCM1664128
+                                })
+        cose_msg.key = cose_key
+        return cose_msg.decrypt().decode('ascii')
+
+    def encrypt_msg(self, msg: str) -> ByteString:
+        """Returns a CBOR-encoded COSE Encrypt0 message"""
+        msg = Enc0Message(
+            phdr={headers.Algorithm: AESCCM1664128},
+            uhdr={headers.IV: self.gen_nonce(self.send_ctx_id)},
+            payload=msg.encode('ascii')
+        )
+        cose_key = SymmetricKey(self.send_ctx_key,
+                                optional_params={
+                                    KpKid: self.send_ctx_id,
+                                    KpAlg: AESCCM1664128
+                                })
+        msg.key = cose_key
+        return msg.encode()

--- a/pyaiot/common/edhoc_keys.py
+++ b/pyaiot/common/edhoc_keys.py
@@ -37,7 +37,7 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
 from cryptography.hazmat.primitives import serialization
 
-from cose.keys.curves import Ed25519
+from cose.curves import Ed25519
 from cose.keys import OKPKey, CoseKey
 from cose.keys.keyparam import KpKid
 from edhoc.roles.edhoc import CoseHeaderMap

--- a/pyaiot/common/edhoc_keys.py
+++ b/pyaiot/common/edhoc_keys.py
@@ -1,0 +1,201 @@
+# Copyright 2017 IoT-Lab Team
+# Contributor(s) : see AUTHORS file
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Pyaiot edhoc keys utility module."""
+
+import os.path
+import base64
+from collections import namedtuple
+
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+from cryptography.hazmat.primitives import serialization
+
+from cose.keys.curves import Ed25519
+from cose.keys import OKPKey, CoseKey
+from cose.keys.keyparam import KpKid
+from edhoc.roles.edhoc import CoseHeaderMap
+from cose.headers import KID
+
+DEFAULT_AUTHKEY_FILENAME = "{}/.pyaiot/authkey.pem".format(
+    os.path.expanduser("~"))
+DEFAULT_AUTHCRED_FILENAME = "{}/.pyaiot/authcred.pem".format(
+    os.path.expanduser("~"))
+DEFAULT_PEER_CRED_FILENAME = "{}/.pyaiot/peercred".format(
+    os.path.expanduser("~"))
+DEFAULT_GATEWAY_RPK_KID = b'20'
+Creds = namedtuple('Creds', ['authkey', 'authcred'])
+
+
+def generate_ed25519_priv_key():
+    """Generate Ed25519 private key"""
+    return Ed25519PrivateKey.generate()
+
+
+def priv_key_serialize_pem(key):
+    """Serialize private key in PEM format"""
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption()
+    ).decode()
+
+
+def pub_key_serialize_pem(key):
+    """Serialize public key in PEM format"""
+    return key.public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode()
+
+
+def _create_parent_dir(filename):
+    """creates parent director of filename if it does not exist"""
+    if not os.path.exists(os.path.dirname(filename)):
+        os.makedirs(os.path.dirname(filename), mode=0o700)
+
+
+def write_edhoc_credentials(authkey, authkey_file=DEFAULT_AUTHKEY_FILENAME,
+                            authcred_file=DEFAULT_AUTHCRED_FILENAME):
+    """Write credentials to filename"""
+    _create_parent_dir(authcred_file)
+    _create_parent_dir(authkey_file)
+    with open(authcred_file, 'w') as f:
+        f.write(pub_key_serialize_pem(authkey.public_key()))
+    with open(authkey_file, 'w') as f:
+        f.write(priv_key_serialize_pem(authkey))
+
+
+def parse_key(filename, private=True):
+    """Returns a CoseKey object from file"""
+    filename = os.path.expanduser(filename)
+    if not os.path.isfile(filename):
+        raise ValueError("Key file provided doesn't exists: '{}'"
+                         .format(filename))
+
+    key = None
+    with open(filename, 'r') as f:
+        key = f.read().encode()
+    try:
+        if private:
+            key = serialization.load_pem_private_key(key, None)
+        else:
+            key = serialization.load_pem_public_key(key, None)
+    except:
+        raise ValueError("Invalid Key in: '{}'".format(filename))
+    if private:
+        if isinstance(key, Ed25519PrivateKey):
+            return key
+        else:
+            raise TypeError("Wrong key type in '{}'".format(filename))
+    else:
+        if isinstance(key, Ed25519PublicKey):
+            return key
+        else:
+            raise TypeError("Wrong key type in '{}'".format(filename))
+
+
+def parse_edhoc_authcred_file(filename=DEFAULT_AUTHCRED_FILENAME):
+    """Returns a CoseKey object from file"""
+    authcred = parse_key(filename, private=False)
+    x = authcred.public_bytes(serialization.Encoding.Raw,
+                              serialization.PublicFormat.Raw)
+    authcred = OKPKey(crv=Ed25519, x=x, optional_params={
+                      KpKid: DEFAULT_GATEWAY_RPK_KID})
+    return authcred
+
+
+def parse_edhoc_authkey_file(filename=DEFAULT_AUTHKEY_FILENAME):
+    """Returns a CoseKey object from file"""
+    authkey = parse_key(filename, private=True)
+    d = authkey.private_bytes(serialization.Encoding.Raw,
+                              serialization.PrivateFormat.Raw,
+                              serialization.NoEncryption())
+    x = authkey.public_key().public_bytes(serialization.Encoding.Raw,
+                                          serialization.PublicFormat.Raw)
+    authkey = OKPKey(crv=Ed25519, d=d, x=x, optional_params={
+                     KpKid: DEFAULT_GATEWAY_RPK_KID})
+    return authkey
+
+
+def get_edhoc_keys(cred_filename=DEFAULT_AUTHCRED_FILENAME,
+                   authkey_filename=DEFAULT_AUTHKEY_FILENAME):
+    """Reads an RPK credentials and authentication key in .pem format, returns
+       OKPKey for each"""
+    authcred = parse_edhoc_authcred_file(cred_filename)
+    authkey = parse_edhoc_authkey_file(authkey_filename)
+    return Creds(authkey=authkey, authcred=authcred)
+
+
+def add_peer_cred(key, kid, filename=DEFAULT_PEER_CRED_FILENAME):
+    """Takes a public key and stores it as an base64 encoded
+       CoseKey, kid must be unique"""
+    _create_parent_dir(filename)
+    cred = OKPKey(crv=Ed25519, x=key, optional_params={KpKid: kid})
+    cred = OKPKey.base64encode(cred.encode())
+
+    if not os.path.exists(filename):
+        with open(filename, "w+") as f:
+            f.write(cred + '\n')
+    else:
+        with open(filename, 'r+') as f:
+            for line in f:
+                key = CoseKey.decode(OKPKey.base64decode(line.strip('\n')))
+                if kid == key.kid:
+                    return False
+            f.write(cred + '\n')
+    return True
+
+
+def rmv_peer_cred(kid, filename=DEFAULT_PEER_CRED_FILENAME):
+    """Removes a peer credential from the list"""
+    if not os.path.exists(filename):
+        return True
+    removed = False
+    with open(filename, "r") as f:
+        lines = f.readlines()
+    with open(filename, "w") as f:
+        for line in lines:
+            key = CoseKey.decode(OKPKey.base64decode(line.strip('\n')))
+            if kid != key.kid:
+                f.write(line)
+            else:
+                removed = True
+    return removed
+
+
+def get_peer_cred(cred_id: CoseHeaderMap, filename=DEFAULT_PEER_CRED_FILENAME):
+    """Look for the the credential matching the id in filename, kid are
+       presumed to be unique"""
+    with open(filename, 'r') as f:
+        for line in f:
+            key = CoseKey.decode(OKPKey.base64decode(line.strip('\n')))
+            if cred_id[KID.identifier] == key.kid:
+                return key
+    return None

--- a/pyaiot/gateway/coap/application.py
+++ b/pyaiot/gateway/coap/application.py
@@ -34,6 +34,7 @@ import logging
 from tornado.options import define, options
 
 from pyaiot.common.auth import check_key_file
+from pyaiot.common.edhoc_keys import get_edhoc_keys
 from pyaiot.common.helpers import start_application, parse_command_line
 
 from .gateway import CoapGateway, MAX_TIME, COAP_PORT
@@ -73,11 +74,12 @@ def run(arguments=[]):
 
     try:
         keys = check_key_file(options.key_file)
+        edhoc_keys = get_edhoc_keys()
     except ValueError as exc:
         logger.error(exc)
         return
 
-    start_application(CoapGateway(keys, options=options),
+    start_application(CoapGateway(keys, edhoc_keys, options=options),
                       port=None, close_client=True)
 
 

--- a/pyaiot/gateway/coap/initiator.py
+++ b/pyaiot/gateway/coap/initiator.py
@@ -1,0 +1,92 @@
+# Copyright 2017 IoT-Lab Team
+# Contributor(s) : see AUTHORS file
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Pyaiot COAP EDHOC Initiator module"""
+
+import logging
+from binascii import unhexlify
+
+from aiocoap import Context, Message
+from aiocoap.numbers.codes import Code
+
+from edhoc.definitions import Correlation, Method, CipherSuite0
+from edhoc.roles.edhoc import CoseHeaderMap
+from edhoc.roles.initiator import Initiator
+
+from cose.headers import KID
+
+import pyaiot.common.edhoc_keys as edhoc_keys
+
+logger = logging.getLogger("pyaiot.edhoc")
+
+INITIATOR_CONNECTION_ID = b''
+
+
+async def handshake(addr, cred, authkey):
+    """Performs an EDHOC handshake over COAP with remote address <addr>"""
+    context = await Context.create_client_context()
+
+    init = Initiator(
+        corr=Correlation.CORR_1,
+        method=Method.SIGN_SIGN,
+        conn_idi=unhexlify(INITIATOR_CONNECTION_ID),
+        cred_idi={KID: cred.kid},
+        auth_key=authkey,
+        cred=cred,
+        remote_cred_cb=get_peer_cred,
+        supported_ciphers=[CipherSuite0],
+        selected_cipher=CipherSuite0,
+        ephemeral_key=None)
+
+    msg_1 = init.create_message_one()
+
+    request = Message(code=Code.POST, payload=msg_1,
+                      uri=f"coap://{addr}/.well-known/edhoc")
+
+    logging.debug(f"POST ({init.edhoc_state}) {request.payload}")
+    response = await context.request(request).response
+
+    logging.debug(f"CHANGED ({init.edhoc_state}), {response.payload}")
+    msg_3 = init.create_message_three(response.payload)
+
+    logging.debug(f"POST ({init.edhoc_state}) {request.payload}")
+    request = Message(code=Code.POST, payload=msg_3,
+                      uri=f"coap://{addr}/.well-known/edhoc")
+    response = await context.request(request).response
+
+    init.finalize()
+    logging.debug('EDHOC key exchange successfully completed:')
+
+    secret = init.exporter('OSCORE Master Secret', 16)
+    salt = init.exporter('OSCORE Master Salt', 8)
+    return salt, secret
+
+
+def get_peer_cred(cred_id: CoseHeaderMap):
+    return edhoc_keys.get_peer_cred(cred_id=cred_id)

--- a/pyaiot/gateway/coap/responder.py
+++ b/pyaiot/gateway/coap/responder.py
@@ -1,0 +1,98 @@
+# Copyright 2017 IoT-Lab Team
+# Contributor(s) : see AUTHORS file
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+# this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its contributors
+# may be used to endorse or promote products derived from this software without
+# specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+"""Pyaiot COAP EDHOC Responder module"""
+
+import logging
+from binascii import unhexlify
+
+import aiocoap
+import aiocoap.resource as resource
+
+from edhoc.definitions import CipherSuite, EdhocState, CipherSuite0
+from edhoc.exceptions import EdhocException
+from edhoc.roles.edhoc import CoseHeaderMap
+from edhoc.roles.responder import Responder
+
+from cose.headers import KID
+
+from pyaiot.common.crypto import CryptoCtx
+import pyaiot.common.edhoc_keys as auth
+
+import logging
+
+logger = logging.getLogger("pyaiot.edhoc")
+
+DEFAULT_CONNECTION_ID = b'2b'
+
+
+class EdhocResource(resource.Resource):
+    def __init__(self, cred, auth_key, crypto_ctx=None):
+        super(EdhocResource, self).__init__()
+        self.cred_idr = {KID: cred.kid}
+        self.cred = cred
+        self.auth_key = auth_key
+        self.supported = [CipherSuite0]
+        self.crypto_ctx = crypto_ctx
+        self.resp = self.create_responder()
+
+    @classmethod
+    def get_peer_cred(cls, cred_id: CoseHeaderMap):
+        return auth.get_peer_cred(cred_id=cred_id)
+
+    def create_responder(self):
+        return Responder(conn_idr=unhexlify(DEFAULT_CONNECTION_ID),
+                         cred_idr=self.cred_idr,
+                         auth_key=self.auth_key,
+                         cred=self.cred,
+                         remote_cred_cb=self.get_peer_cred,
+                         supported_ciphers=[CipherSuite0],
+                         ephemeral_key=None)
+
+    async def render_post(self, request):
+        if self.resp.edhoc_state == EdhocState.EDHOC_WAIT:
+            logger.info('EDHOC got message 2')
+            msg_2 = self.resp.create_message_two(request.payload)
+            return aiocoap.Message(code=aiocoap.Code.CHANGED, payload=msg_2)
+
+        elif self.resp.edhoc_state == EdhocState.MSG_2_SENT:
+            self.resp.finalize(request.payload)
+            logger.debug('EDHOC key exchange successfully completed:')
+
+            if self.crypto_ctx:
+                secret = self.resp.exporter('OSCORE Master Secret', 16)
+                salt = self.resp.exporter('OSCORE Master Salt', 8)
+                self.crypto_ctx.generate_aes_ccm_keys(salt, secret)
+
+            # initialize new Responder object
+            self.resp = self.create_responder()
+
+            return aiocoap.Message(code=aiocoap.Code.CHANGED)
+        else:
+            raise EdhocException(f"Illegal state: {self.resp.edhoc_state}")

--- a/pyaiot/gateway/common/gateway.py
+++ b/pyaiot/gateway/common/gateway.py
@@ -61,16 +61,16 @@ class GatewayBaseMixin():
         self.send_to_broker(Message.new_node(node.uid))
         for res, value in node.resources.items():
             self.send_to_broker(Message.update_node(node.uid, res, value))
-        await self.discover_node(node)
+        await self.discover_node(node, handshake=True)
 
-    def reset_node(self, node, default_resources={}):
+    async def reset_node(self, node, default_resources={}):
         """Reset a node: clear the current resource and reinitialize them."""
         node.clear_resources()
         node.set_resource_value('protocol', self.PROTOCOL)
         for resource, value in default_resources.items():
             node.set_resource_value(resource, value)
         self.send_to_broker(Message.reset_node(node.uid))
-        self.discover_node(node)
+        await self.discover_node(node, handshake=True)
 
     def remove_node(self, node):
         """Remove the given node from known nodes and notify the broker."""
@@ -207,7 +207,7 @@ class GatewayBase(web.Application, GatewayBaseMixin, metaclass=ABCMeta):
         Should be a coroutine."""
 
     @abstractmethod
-    def discover_node(self, node):
+    def discover_node(self, node, handshake=False):
         """Start a discovery procedure on a node.
 
         After the discovery is done, all resources (or endpoints) exposed by a

--- a/pyaiot/gateway/common/node.py
+++ b/pyaiot/gateway/common/node.py
@@ -32,16 +32,20 @@
 import logging
 import time
 
+from pyaiot.common.crypto import CryptoCtx
+
 logger = logging.getLogger("pyaiot.gw.common.node")
 
 
 class Node():
     """Class for managed nodes."""
 
+    GW_RECV_CTX_ID = b'\xea\xea\xd4H\xe0V\xef\x83'
+
     def __init__(self, uid, **default_resources):
         self.uid = uid
         self.last_seen = time.time()
-
+        self.ctx = CryptoCtx(self.GW_RECV_CTX_ID, uid.encode('utf-8'))
         self.resources = default_resources
 
     def __eq__(self, other):
@@ -64,3 +68,6 @@ class Node():
 
     def clear_resources(self):
         self.resources = {}
+
+    def has_crypto_ctx(self):
+        return self.ctx.recv_ctx_key != None

--- a/pyaiot/tests/test_crypto.py
+++ b/pyaiot/tests/test_crypto.py
@@ -1,0 +1,73 @@
+"""pyaiot crypto test module."""
+
+from pyaiot.common.crypto import CryptoCtx, CypherMessage
+
+ALICE_ID = b'\xcc\xd1'
+BOB_ID = b'\xac\xe2'
+SALT = b'\xea\xea\xd4H\xe0V\xef\x83'
+SECRET = b'\x16lE\xab\xb8\xd6\xdb\xe5\xd7q\xeb\x1d\x8b !\xa4'
+
+PLAIN_TEXT = b"a secret message"
+AAD_DATA = b"authenticated but unencrypted data"
+
+PLAIN_TEXT_STRING = "a secret message"
+CYPHER_MESSAGE_STRING = "{\"ct\": \"ct\", \"aad\": \"aad\"}"
+
+
+def test_generate_keys_bob_alice_match():
+    """Basic test, generated aes-ccm keys should match"""
+    bob = CryptoCtx(BOB_ID, ALICE_ID)
+    alice = CryptoCtx(ALICE_ID, BOB_ID)
+    bob.generate_aes_ccm_keys(SALT, SECRET)
+    alice.generate_aes_ccm_keys(SALT, SECRET)
+
+    assert bob.common_iv == alice.common_iv
+    assert bob.send_ctx_key == alice.recv_ctx_key
+    assert alice.send_ctx_key == bob.recv_ctx_key
+
+
+def test_bob_alice_encrypt_decrypt():
+    """Test AES-CCM encryption decryption"""
+    bob = CryptoCtx(BOB_ID, ALICE_ID)
+    alice = CryptoCtx(ALICE_ID, BOB_ID)
+    bob.generate_aes_ccm_keys(SALT, SECRET)
+    alice.generate_aes_ccm_keys(SALT, SECRET)
+    cypher_text = bob.encrypt(PLAIN_TEXT, AAD_DATA)
+    plain_text = alice.decrypt(cypher_text, AAD_DATA)
+    assert plain_text == PLAIN_TEXT
+
+
+def test_cypher_message_new_parse():
+    """Create a new encrypted message and decode a received message"""
+    bob = CryptoCtx(BOB_ID, ALICE_ID)
+    alice = CryptoCtx(ALICE_ID, BOB_ID)
+    bob.generate_aes_ccm_keys(SALT, SECRET)
+    alice.generate_aes_ccm_keys(SALT, SECRET)
+    message = bob.create_msg(PLAIN_TEXT_STRING)
+    plain_text = alice.parse_msg(message)
+    assert plain_text == PLAIN_TEXT_STRING
+
+
+def test_cypher_message_to_json_str():
+    """Convert CypherMessage to json string"""
+    cypher_msg = CypherMessage("ct", "aad")
+    cypher_msg_str = cypher_msg.to_json_str()
+    assert cypher_msg_str == CYPHER_MESSAGE_STRING
+
+
+def test_cypher_messsage_from_json_string():
+    """Test convertion of CypherMessage from JSON string"""
+    cypher_msg = CypherMessage.from_json_str(CYPHER_MESSAGE_STRING)
+    assert cypher_msg.aad == "aad"
+    assert cypher_msg.ct == "ct"
+
+
+def test_crypto_encrypt_decrypt_msg():
+    """Test cose encryption decryption of a message"""
+    bob = CryptoCtx(BOB_ID, ALICE_ID)
+    alice = CryptoCtx(ALICE_ID, BOB_ID)
+    bob.generate_aes_ccm_keys(SALT, SECRET)
+    alice.generate_aes_ccm_keys(SALT, SECRET)
+    encoded_msg = bob.encrypt_msg(PLAIN_TEXT_STRING)
+    decoded_msg = alice.decrypt_msg(encoded_msg)
+    assert decoded_msg == PLAIN_TEXT_STRING

--- a/pyaiot/tests/test_edhoc_keys.py
+++ b/pyaiot/tests/test_edhoc_keys.py
@@ -1,0 +1,102 @@
+"""pyaiot auth test module."""
+
+import pytest
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+from cryptography.hazmat.primitives import serialization
+from cose.keys import OKPKey
+from cose.headers import KID
+
+import pyaiot.common.edhoc_keys as edhoc_keys
+
+
+RSA_PEM_KEY = """
+-----BEGIN RSA PRIVATE KEY-----
+MIICXAIBAAKBgQCqGKukO1De7zhZj6+H0qtjTkVxwTCpvKe4eCZ0FPqri0cb2JZfXJ/DgYSF6vUp
+wmJG8wVQZKjeGcjDOL5UlsuusFncCzWBQ7RKNUSesmQRMSGkVb1/3j+skZ6UtW+5u09lHNsj6tQ5
+1s1SPrCBkedbNf0Tp0GbMJDyR4e9T04ZZwIDAQABAoGAFijko56+qGyN8M0RVyaRAXz++xTqHBLh
+3tx4VgMtrQ+WEgCjhoTwo23KMBAuJGSYnRmoBZM3lMfTKevIkAidPExvYCdm5dYq3XToLkkLv5L2
+pIIVOFMDG+KESnAFV7l2c+cnzRMW0+b6f8mR1CJzZuxVLL6Q02fvLi55/mbSYxECQQDeAw6fiIQX
+GukBI4eMZZt4nscy2o12KyYner3VpoeE+Np2q+Z3pvAMd/aNzQ/W9WaI+NRfcxUJrmfPwIGm63il
+AkEAxCL5HQb2bQr4ByorcMWm/hEP2MZzROV73yF41hPsRC9m66KrheO9HPTJuo3/9s5p+sqGxOlF
+L0NDt4SkosjgGwJAFklyR1uZ/wPJjj611cdBcztlPdqoxssQGnh85BzCj/u3WqBpE2vjvyyvyI5k
+X6zk7S0ljKtt2jny2+00VsBerQJBAJGC1Mg5Oydo5NwD6BiROrPxGo2bpTbu/fhrT8ebHkTz2epl
+U9VQQSQzY1oZMVX8i1m5WUTLPz2yLJIBQVdXqhMCQBGoiuSoSjafUhV7i1cEGpb88h5NBYZzWXGZ
+37sJ5QsW+sJyoNde3xH8vdXhzU7eT82D6X/scw9RZz+/6rCJ4p0=
+-----END RSA PRIVATE KEY-----
+"""
+
+
+def test_write_edhoc_credentials(tmp_path):
+    authkey_path = tmp_path / "authkey.pem"
+    authcred_path = tmp_path / "cred.pem"
+    authkey = edhoc_keys.generate_ed25519_priv_key()
+    edhoc_keys.write_edhoc_credentials(authkey, authkey_path,
+                                       authcred_path)
+    file_authkey = edhoc_keys.parse_edhoc_authkey_file(authkey_path)
+    file_authcred = edhoc_keys.parse_edhoc_authcred_file(authcred_path)
+    assert file_authkey.d == authkey.private_bytes(
+        serialization.Encoding.Raw,
+        serialization.PrivateFormat.Raw,
+        serialization.NoEncryption())
+    authcred = authkey.public_key()
+    assert file_authcred.x == authcred.public_bytes(
+        serialization.Encoding.Raw,
+        serialization.PublicFormat.Raw)
+
+
+def test_parse_key_wrong_type(tmp_path):
+    path = tmp_path / "wrongkey.pem"
+    path.write_text(RSA_PEM_KEY)
+    with pytest.raises(TypeError):
+        edhoc_keys.parse_key(path)
+
+
+def test_parse_key_invalid_key(tmp_path):
+    path = tmp_path / "wrongkey.pem"
+    path.write_text("asdfasdf")
+    with pytest.raises(ValueError):
+        edhoc_keys.parse_key(path)
+
+
+def test_get_edhoc_keys(tmp_path):
+    authkey_path = tmp_path / "authkey.pem"
+    authcred_path = tmp_path / "cred.pem"
+    authkey = edhoc_keys.generate_ed25519_priv_key()
+    edhoc_keys.write_edhoc_credentials(authkey, authkey_path,
+                                       authcred_path)
+    creds = edhoc_keys.get_edhoc_keys(authcred_path, authkey_path)
+    assert isinstance(creds.authkey, OKPKey)
+    assert isinstance(creds.authcred, OKPKey)
+
+
+def test_add_peer_cred(tmp_path):
+    path = tmp_path / "peercred"
+    cred1 = "0zwe1YPaPxdq3fOtQPkzvvDoiOyPOo1jTmJMgnpo2SA="
+    cred2 = "YF/5Nehu2apKdzIgC97gmp+iWFYs0JB4DnFFNbF2zFo="
+    assert edhoc_keys.add_peer_cred(cred1, b'20', path)
+    assert not edhoc_keys.add_peer_cred(cred1, b'20', path)
+    assert edhoc_keys.add_peer_cred(cred2, b'21', path)
+
+
+def test_rmv_peer_cred(tmp_path):
+    path = tmp_path / "peercred"
+    cred1 = b'\xd3<\x1e\xd5\x83\xda?\x17j\xdd\xf3\xad@\xf93\xbe\xf0\xe8\x88\xec\x8f:\x8dcNbL\x82zh\xd9 '
+    cred2 = b'`_\xf95\xe8n\xd9\xaaJw2 \x0b\xde\xe0\x9a\x9f\xa2XV,\xd0\x90x\x0eqE5\xb1v\xccZ'
+    assert edhoc_keys.add_peer_cred(cred1, b'20', path)
+    assert edhoc_keys.add_peer_cred(cred2, b'21', path)
+    assert edhoc_keys.rmv_peer_cred(b'20', path)
+    assert edhoc_keys.rmv_peer_cred(b'21', path)
+    assert not edhoc_keys.rmv_peer_cred(b'20', path)
+
+
+def test_get_peer_cred(tmp_path):
+    path = tmp_path / "peercred"
+    cred1 = b'\xd3<\x1e\xd5\x83\xda?\x17j\xdd\xf3\xad@\xf93\xbe\xf0\xe8\x88\xec\x8f:\x8dcNbL\x82zh\xd9 '
+    cred2 = b'`_\xf95\xe8n\xd9\xaaJw2 \x0b\xde\xe0\x9a\x9f\xa2XV,\xd0\x90x\x0eqE5\xb1v\xccZ'
+    assert edhoc_keys.add_peer_cred(cred1, b'20', path)
+    assert edhoc_keys.add_peer_cred(cred2, b'21', path)
+    key = edhoc_keys.get_peer_cred({KID.identifier: b'20'}, path)
+    assert key.kid == b'20'
+    assert key.x == cred1
+    key = edhoc_keys.get_peer_cred({KID.identifier: b'22'}, path)
+    assert key == None

--- a/setup.py
+++ b/setup.py
@@ -73,12 +73,15 @@ if __name__ == '__main__':
                    pjoin('bin', 'aiot-mqtt-gateway'),
                    pjoin('bin', 'aiot-ws-gateway'),
                    pjoin('bin', 'aiot-dashboard'),
+                   pjoin('bin', 'aiot-generate-edhoc'),
+                   pjoin('bin', 'aiot-add-key'),
                    pjoin('bin', 'aiot-generate-keys')],
           install_requires=[
             'tornado>=6.0',
-            'aiocoap>=0.3',
-            'gmqtt',
-            'cryptography>=1.7.2'
+            'aiocoap>=0.4',
+            'hbmqtt>=0.8',
+            'cryptography>=1.7.2',
+            'edhoc @ git+https://github.com/openwsn-berkeley/py-edhoc.git'
           ],
           classifiers=[
             'Development Status :: 4 - Beta',

--- a/utils/coap/coap-test-node.py
+++ b/utils/coap/coap-test-node.py
@@ -38,6 +38,7 @@ import aiocoap
 import aiocoap.resource as resource
 from aiocoap import Context, Message, GET, POST
 
+
 logging.basicConfig(level=logging.DEBUG,
                     format='%(asctime)s - %(name)14s - '
                            '%(levelname)5s - %(message)s')

--- a/utils/coap/coap-test-node.py
+++ b/utils/coap/coap-test-node.py
@@ -33,10 +33,25 @@ import logging
 import random
 import argparse
 import asyncio
+from pathlib import Path
 
 import aiocoap
 import aiocoap.resource as resource
 from aiocoap import Context, Message, GET, POST
+
+from pyaiot.common.crypto import CryptoCtx
+from pyaiot.common.edhoc_keys import (get_edhoc_keys,
+                                      add_peer_cred,
+                                      rmv_peer_cred,
+                                      generate_ed25519_priv_key)
+from pyaiot.gateway.coap.responder import EdhocResource
+
+from cryptography.hazmat.primitives import serialization
+from cose.curves import Ed25519
+from cose.keys import OKPKey
+from cose.keys.keyparam import KpKid
+from edhoc.roles.edhoc import CoseHeaderMap
+from cose.headers import KID
 
 
 logging.basicConfig(level=logging.DEBUG,
@@ -63,12 +78,18 @@ parser.add_argument('--js', action="store_true",
                     help="Activate Javascript endpoint.")
 parser.add_argument('--version', action="store_true",
                     help="Activate Version endpoint.")
+parser.add_argument('--edhoc', action="store_true",
+                    help="Activate EDHOC endpoint.")
 args = parser.parse_args()
 
 
 COAP_GATEWAY = 'coap://{}:{}'.format(args.gateway_host, args.gateway_port)
 
 NODE_UID = "1234"
+
+GW_RECV_CTX_ID = b'\xea\xea\xd4H\xe0V\xef\x83'
+CRYPTO_CTX = CryptoCtx(NODE_UID.encode('utf-8'), GW_RECV_CTX_ID)
+DEFAULT_COAP_TEST_NODE_RPK_KID = b'2b'
 
 
 async def _coap_resource(url, method=GET, payload=b''):
@@ -98,9 +119,13 @@ async def _send_alive():
 
 
 async def _send_temperature():
-    payload = ("temperature:{}°C"
-               .format(random.randrange(20, 30, 1))
-               .encode('utf-8'))
+    value = "temperature:{}°C".format(random.randrange(20, 30, 1))
+    if CRYPTO_CTX.recv_ctx_key != None:
+        payload = CRYPTO_CTX.encrypt_msg(value)
+    else:
+        return
+        payload = value.encode('utf-8')
+    print("sending: {}".format(payload))
     _, _ = await _coap_resource('{}/{}'.format(COAP_GATEWAY, "server"),
                                 method=POST,
                                 payload=payload)
@@ -201,8 +226,8 @@ class LedResource(resource.Resource):
         payload = ("Updated").encode('utf-8')
 
         await _coap_resource('{}/{}'.format(COAP_GATEWAY, "server"),
-                            method=POST, payload="led:{}"
-                            .format(self.value).encode())
+                             method=POST, payload="led:{}"
+                             .format(self.value).encode())
 
         return aiocoap.Message(code=aiocoap.CHANGED, payload=payload)
 
@@ -224,10 +249,16 @@ class TemperatureResource(resource.Resource):
 
     def __init__(self):
         super(TemperatureResource, self).__init__()
-        self.value = "23°C".encode("utf-8")
+        self.value = "23°C".encode('utf-8')
 
     async def render_get(self, request):
-        response = aiocoap.Message(code=aiocoap.CONTENT, payload=self.value)
+        value = self.value
+        if CRYPTO_CTX.recv_ctx_key != None:
+            payload = CRYPTO_CTX.encrypt_msg(
+                payload.decode('utf-8'))
+        else:
+            payload = value
+        response = aiocoap.Message(code=aiocoap.CONTENT, payload=payload)
         return response
 
 
@@ -310,6 +341,26 @@ async def periodic(func, delay):
 
 
 if __name__ == '__main__':
+    authkey = generate_ed25519_priv_key()
+    authcred = authkey.public_key()
+    rpk_bytes = authcred.public_bytes(
+        encoding=serialization.Encoding.Raw,
+        format=serialization.PublicFormat.Raw,
+    )
+    rmv_peer_cred(DEFAULT_COAP_TEST_NODE_RPK_KID)
+    add_peer_cred(rpk_bytes, DEFAULT_COAP_TEST_NODE_RPK_KID)
+    x = authcred.public_bytes(serialization.Encoding.Raw,
+                              serialization.PublicFormat.Raw)
+    authcred = OKPKey(crv=Ed25519, x=x, optional_params={
+                      KpKid: DEFAULT_COAP_TEST_NODE_RPK_KID})
+    d = authkey.private_bytes(serialization.Encoding.Raw,
+                              serialization.PrivateFormat.Raw,
+                              serialization.NoEncryption())
+    x = authkey.public_key().public_bytes(serialization.Encoding.Raw,
+                                          serialization.PublicFormat.Raw)
+    authkey = OKPKey(crv=Ed25519, d=d, x=x, optional_params={
+                     KpKid: DEFAULT_COAP_TEST_NODE_RPK_KID})
+
     try:
         # Tornado ioloop initialization
         ioloop = asyncio.get_event_loop()
@@ -342,9 +393,13 @@ if __name__ == '__main__':
             root.add_resource(('js', ), JavascriptResource())
         if args.version:
             root.add_resource(('version', ), VersionResource())
+        if args.edhoc:
+            root.add_resource(('.well-known', 'edhoc'),
+                              EdhocResource(authcred, authkey,
+                                            crypto_ctx=CRYPTO_CTX))
         root.add_resource(('.well-known', 'core'),
                           resource.WKCResource(
-                              root.get_resources_as_linkheader))
+                              root.get_resources_as_linkheader, impl_info=None))
         asyncio.ensure_future(aiocoap.Context.create_server_context(root))
 
         _send_alive()


### PR DESCRIPTION
This PR implements a POC of a poor man's OSCORE to secure application content between the nodes and the gateway. Its not using OSCORE directly because there is currently no OSCORE support in RIOT.

Its done on the coap-gateway because currently the broker is stateless and the dashboard is running in JS so I do not have a EDHOC implementation in JS to use ATM.

The idea is quite simple: if an `well-known/core/edhoc` resource is discovered a handshake in initiated, if a security context is derived then encryption will happen on both sides and decryption will be attempted as well.

IMO this handshake would be better suited to happen on the last hop, so the dashboard or eventually a backend (where sensor data would be stored for example).